### PR TITLE
Serde parser

### DIFF
--- a/yam-core/Cargo.toml
+++ b/yam-core/Cargo.toml
@@ -28,6 +28,7 @@ exclude =[
 
 
 [dependencies]
+log = "0.4.29"
 
 [features]
 default = []

--- a/yam-core/src/lazy_expander.rs
+++ b/yam-core/src/lazy_expander.rs
@@ -1,0 +1,50 @@
+use crate::parsing::ScalarValue;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+pub enum LazyExpander<'input> {
+    Scalar(ScalarValue<'input>),
+    Vector(Box<LazyExpanderVec<'input>>),
+    Map(Box<LazyExpanderMap<'input>>),
+}
+
+pub trait Expanable {
+    fn calculate_limit(&self) -> usize;
+    fn can_expand(&self, limit: usize) -> bool {
+        limit > self.calculate_limit()
+    }
+}
+
+impl<'input> Expanable for LazyExpander<'input> {
+    fn calculate_limit(&self) -> usize {
+        match self {
+            LazyExpander::Scalar(_) => 1,
+            LazyExpander::Vector(vec) => vec.calculate_limit(),
+            LazyExpander::Map(map) => map.calculate_limit(),
+        }
+    }
+}
+
+pub struct LazyExpanderVec<'input> {
+    pub inner: Vec<LazyExpander<'input>>,
+}
+
+impl<'input> Expanable for LazyExpanderVec<'input> {
+    fn calculate_limit(&self) -> usize {
+        self.inner
+            .iter()
+            .fold(0, |acc, expansion| acc + expansion.calculate_limit())
+    }
+}
+
+pub struct LazyExpanderMap<'input> {
+    inner: Vec<(LazyExpander<'input>, LazyExpander<'input>)>,
+}
+
+impl<'input> Expanable for LazyExpanderMap<'input> {
+    fn calculate_limit(&self) -> usize {
+        self.inner.iter().fold(0, |acc, expansion| {
+            acc + expansion.0.calculate_limit() + expansion.1.calculate_limit()
+        })
+    }
+}

--- a/yam-core/src/lib.rs
+++ b/yam-core/src/lib.rs
@@ -34,6 +34,10 @@ extern crate core;
 #[doc(hidden)]
 pub mod escaper;
 
+#[doc(hidden)]
+pub use lazy_expander::{Expanable, LazyExpander, LazyExpanderMap, LazyExpanderVec};
+
+mod lazy_expander;
 pub mod node;
 pub mod parsing;
 pub mod prelude;

--- a/yam-core/src/node/mod.rs
+++ b/yam-core/src/node/mod.rs
@@ -1,5 +1,6 @@
 //! Import this module to use various `yam_core` nodes.
 pub use scalar::YamlScalar;
+pub use scalar::parse_i64_from_cow;
 pub use spanned_yaml::SpannedYaml;
 pub use yaml::Yaml;
 pub use yaml_data::YamlData;

--- a/yam-core/src/node/scalar.rs
+++ b/yam-core/src/node/scalar.rs
@@ -95,7 +95,7 @@ where
             if tag.is_yaml_core_schema() {
                 match tag.suffix.as_ref() {
                     "bool" => v.parse::<bool>().ok().map(|x| Self::Bool(x)),
-                    "int" => v.parse::<i64>().ok().map(|x| Self::Integer(x.into())),
+                    "int" => parse_i64_from_cow(&v).ok().map(|x| Self::Integer(x.into())),
                     "float" => parse_core_schema_fp(&v).map(|x| Self::FloatingPoint(x.into())),
                     "null" => match v.as_ref() {
                         "~" | "null" => Some(Self::Null(PhantomData)),
@@ -165,7 +165,7 @@ where
             _ => {}
         }
 
-        if let Ok(integer) = s.parse::<i64>() {
+        if let Ok(integer) = parse_i64_from_cow(s) {
             return Self::Integer(integer.into());
         }
 
@@ -196,6 +196,10 @@ pub fn parse_core_schema_fp(v: &str) -> Option<f64> {
         _ if v.as_bytes().iter().any(u8::is_ascii_digit) => v.parse::<f64>().ok(),
         _ => None,
     }
+}
+
+pub fn parse_i64_from_cow(v: &str) -> Result<i64, core::num::ParseIntError> {
+    v.parse::<i64>()
 }
 
 impl<F, STR, INT> Clone for YamlScalar<'_, F, INT, STR>

--- a/yam-core/src/node/scalar.rs
+++ b/yam-core/src/node/scalar.rs
@@ -198,6 +198,7 @@ pub fn parse_core_schema_fp(v: &str) -> Option<f64> {
     }
 }
 
+#[doc(hidden)]
 pub fn parse_i64_from_cow(v: &str) -> Result<i64, core::num::ParseIntError> {
     v.parse::<i64>()
 }

--- a/yam-core/src/node/scalar.rs
+++ b/yam-core/src/node/scalar.rs
@@ -51,12 +51,7 @@ where
     }
 }
 
-impl<'a, F, S, I> YamlScalar<'a, F, I, S>
-where
-    F: From<f64>,
-    S: From<Cow<'a, str>>,
-    I: From<i64>,
-{
+impl<'a> YamlScalar<'a> {
     /// Parse a scalar node representation into a [`YamlScalar`].
     ///
     /// If `tag` is not [`None`]:
@@ -70,7 +65,14 @@ where
     pub fn parse_from_scalar(value: ScalarValue<'a>) -> Option<Self> {
         Self::parse_from_cow_and_metadata(value.value, value.scalar_type, value.tag)
     }
+}
 
+impl<'a, F, S, I> YamlScalar<'a, F, I, S>
+where
+    F: From<f64>,
+    S: From<Cow<'a, str>>,
+    I: From<i64>,
+{
     /// Parse a scalar node representation into a [`YamlScalar`].
     ///
     /// If `tag` is not [`None`]:

--- a/yam-core/src/node/scalar.rs
+++ b/yam-core/src/node/scalar.rs
@@ -1,3 +1,4 @@
+use crate::parsing::ScalarValue;
 use crate::prelude::{ScalarType, Tag};
 use alloc::borrow::Cow;
 use core::marker::PhantomData;
@@ -66,15 +67,29 @@ where
     /// # Return
     /// Returns the parsed [`YamlScalar`].
     ///
+    pub fn parse_from_scalar(value: ScalarValue<'a>) -> Option<Self> {
+        Self::parse_from_cow_and_metadata(value.value, value.scalar_type, value.tag)
+    }
+
+    /// Parse a scalar node representation into a [`YamlScalar`].
+    ///
+    /// If `tag` is not [`None`]:
+    ///   - If the handle is `tag:yaml.org,2022:`, attempt to parse as the given suffix. If parsing
+    ///     fails or the suffix is unknown, return [`None`].
+    ///   - If the handle is unknown, use the fallback parsing schema.
+    ///
+    /// # Return
+    /// Returns the parsed [`YamlScalar`].
+    ///
     pub fn parse_from_cow_and_metadata(
         v: Cow<'a, str>,
-        style: ScalarType,
-        tag: Option<&Cow<'a, Tag>>,
+        scalar_type: ScalarType,
+        tag: Option<Cow<'a, Tag>>,
     ) -> Option<Self> {
-        if style != ScalarType::Plain {
+        if scalar_type != ScalarType::Plain {
             // Any quoted scalar is a string.
             Some(Self::String(v.into()))
-        } else if let Some(tag) = tag.map(Cow::as_ref) {
+        } else if let Some(tag) = tag {
             if tag.is_yaml_core_schema() {
                 match tag.suffix.as_ref() {
                     "bool" => v.parse::<bool>().ok().map(|x| Self::Bool(x)),

--- a/yam-core/src/node/yaml_data.rs
+++ b/yam-core/src/node/yaml_data.rs
@@ -103,7 +103,7 @@ where
                 tag.clone(),
                 Box::new(Self::value_from_cow_and_metadata(v, style, None).into()),
             ),
-            _ => YamlScalar::<FP, INT, STR>::parse_from_cow_and_metadata(v, style, tag)
+            _ => YamlScalar::<FP, INT, STR>::parse_from_cow_and_metadata(v, style, tag.cloned())
                 .map_or(YamlData::BadValue, |x| YamlData::Scalar(x)),
         }
     }

--- a/yam-core/src/parsing/mod.rs
+++ b/yam-core/src/parsing/mod.rs
@@ -16,6 +16,7 @@ use core::fmt::{Display, Formatter};
 pub use parser::EventReceiver;
 pub use parser::SpannedEventReceiver;
 pub use parser::{Event, Parser, ScalarValue};
+pub use parser_iter::ParserIter;
 pub use source::Source;
 pub use source::StrSource;
 

--- a/yam-core/src/parsing/mod.rs
+++ b/yam-core/src/parsing/mod.rs
@@ -3,6 +3,7 @@
 mod buffered_source;
 mod char_utils;
 mod parser;
+pub mod parser_iter;
 mod scanner;
 mod source;
 

--- a/yam-core/src/parsing/parser.rs
+++ b/yam-core/src/parsing/parser.rs
@@ -166,6 +166,10 @@ impl<'input> Event<'input> {
     pub fn is_scalar(&self) -> bool {
         matches!(self, Event::Scalar(_))
     }
+
+    pub fn is_doc_start(&self) -> bool {
+        matches!(self, Event::DocumentStart(_))
+    }
 }
 
 /// A YAML parser.

--- a/yam-core/src/parsing/parser.rs
+++ b/yam-core/src/parsing/parser.rs
@@ -170,6 +170,23 @@ impl<'input> Event<'input> {
     pub fn is_doc_start(&self) -> bool {
         matches!(self, Event::DocumentStart(_))
     }
+
+    pub fn as_simple_str(&self) -> &'static str {
+        match self {
+            Event::Nothing => "Nothing",
+            Event::StreamStart => "StreamStart",
+            Event::StreamEnd => "StreamEnd",
+            Event::DocumentStart(_) => "DocumentStart",
+            Event::DocumentEnd => "DocumentEnd",
+            Event::Alias(_) => "Alias",
+            Event::Comment(_) => "Comment",
+            Event::Scalar(_) => "Scalar",
+            Event::SequenceStart(_, _) => "SequenceStart",
+            Event::SequenceEnd => "SequenceEnd",
+            Event::MappingStart(_, _) => "MappingStart",
+            Event::MappingEnd => "MappingEnd",
+        }
+    }
 }
 
 /// A YAML parser.

--- a/yam-core/src/parsing/parser.rs
+++ b/yam-core/src/parsing/parser.rs
@@ -162,6 +162,10 @@ impl<'input> Event<'input> {
     fn empty_scalar() -> Event<'input> {
         Event::Scalar(ScalarValue::empty_scalar())
     }
+
+    pub fn is_scalar(&self) -> bool {
+        matches!(self, Event::Scalar(_))
+    }
 }
 
 /// A YAML parser.
@@ -425,7 +429,7 @@ impl<'input, T: Source> Parser<'input, T> {
     /// [`Self::next_event`] should conform to the expectations of an [`Iterator`] and return an
     /// option. This burdens the parser code. This function is used internally when an option is
     /// undesirable.
-    fn next_event_impl<'a>(&mut self) -> ParseResult<'a>
+    pub fn next_event_impl<'a>(&mut self) -> ParseResult<'a>
     where
         'input: 'a,
     {

--- a/yam-core/src/parsing/parser_iter.rs
+++ b/yam-core/src/parsing/parser_iter.rs
@@ -2,14 +2,12 @@ use crate::parsing::{Event, Parser, ScalarValue, Source, StrSource, Tag};
 use crate::prelude::YamlError;
 use alloc::borrow::Cow;
 use core::ops::ControlFlow;
-use log::debug;
 
 #[derive(Default, PartialEq, Eq, Clone, Copy)]
 enum State {
     #[default]
     StreamStart,
     InDocument,
-    Sequence,
     EndDocument,
 }
 
@@ -17,6 +15,7 @@ pub enum YamEvent<'de> {
     DocStart,
     DocEnd,
     StreamEnd,
+    Alias(usize),
     Scalar(ScalarValue<'de>),
     SeqStart(usize, Option<Cow<'de, Tag>>),
     SeqEnd,
@@ -24,13 +23,14 @@ pub enum YamEvent<'de> {
     MapEnd,
 }
 
-struct ParserIter<'de, R: Source> {
+pub struct ParserIter<'de, R: Source> {
     parser: Parser<'de, R>,
     state: State,
+    error: Option<YamlError>,
 }
 
 impl<'a> ParserIter<'a, StrSource<'a>> {
-    pub fn from_str<S: AsRef<str>>(input: &'a S) -> Self {
+    pub fn from_str_ref<S: AsRef<str>>(input: &'a S) -> Self {
         Self::new(StrSource::new(input.as_ref()))
     }
 }
@@ -43,6 +43,7 @@ where
         Self {
             parser: Parser::new(input),
             state: State::StreamStart,
+            error: None,
         }
     }
 }
@@ -61,13 +62,12 @@ where
                     ControlFlow::Break(flow) => break flow,
                     ControlFlow::Continue(()) => continue,
                 },
-                State::Sequence => {}
                 State::EndDocument => break self.finish_document(),
             }
         };
         match res {
             Err(e) => {
-                debug!("{e}");
+                self.error = Some(e);
                 None
             }
             Ok(YamEvent::StreamEnd) => None,

--- a/yam-core/src/parsing/parser_iter.rs
+++ b/yam-core/src/parsing/parser_iter.rs
@@ -11,6 +11,7 @@ enum State {
     EndDocument,
 }
 
+#[derive(Debug)]
 pub enum YamEvent<'de> {
     DocStart,
     DocEnd,

--- a/yam-core/src/parsing/parser_iter.rs
+++ b/yam-core/src/parsing/parser_iter.rs
@@ -1,0 +1,139 @@
+use crate::parsing::{Event, Parser, ScalarValue, Source, StrSource, Tag};
+use crate::prelude::YamlError;
+use alloc::borrow::Cow;
+use core::ops::ControlFlow;
+use log::debug;
+
+#[derive(Default, PartialEq, Eq, Clone, Copy)]
+enum State {
+    #[default]
+    StreamStart,
+    InDocument,
+    Sequence,
+    EndDocument,
+}
+
+pub enum YamEvent<'de> {
+    DocStart,
+    DocEnd,
+    StreamEnd,
+    Scalar(ScalarValue<'de>),
+    SeqStart(usize, Option<Cow<'de, Tag>>),
+    SeqEnd,
+    MapStart(usize, Option<Cow<'de, Tag>>),
+    MapEnd,
+}
+
+struct ParserIter<'de, R: Source> {
+    parser: Parser<'de, R>,
+    state: State,
+}
+
+impl<'a> ParserIter<'a, StrSource<'a>> {
+    pub fn from_str<S: AsRef<str>>(input: &'a S) -> Self {
+        Self::new(StrSource::new(input.as_ref()))
+    }
+}
+
+impl<'de, R> ParserIter<'de, R>
+where
+    R: Source,
+{
+    fn new(input: R) -> Self {
+        Self {
+            parser: Parser::new(input),
+            state: State::StreamStart,
+        }
+    }
+}
+
+impl<'de, R> Iterator for ParserIter<'de, R>
+where
+    R: Source,
+{
+    type Item = YamEvent<'de>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = loop {
+            match self.state {
+                State::StreamStart => break self.process_start(),
+                State::InDocument => match self.process_doc() {
+                    ControlFlow::Break(flow) => break flow,
+                    ControlFlow::Continue(()) => continue,
+                },
+                State::Sequence => {}
+                State::EndDocument => break self.finish_document(),
+            }
+        };
+        match res {
+            Err(e) => {
+                debug!("{e}");
+                None
+            }
+            Ok(YamEvent::StreamEnd) => None,
+            Ok(res) => Some(res),
+        }
+    }
+}
+impl<'de, R: Source> ParserIter<'de, R> {
+    pub(crate) fn process_start(&mut self) -> Result<YamEvent<'de>, YamlError> {
+        // Expect a <stream-start>
+        let ev = self.parser.next_event_impl()?.0;
+        if ev != Event::StreamStart {
+            return Err(YamlError::new_custom("Expected Stream start"));
+        }
+        // Expect a <doc-start>
+        let ev = self.parser.next_event_impl()?.0;
+        if !ev.is_doc_start() {
+            return Err(YamlError::new_custom("Expected Document start"));
+        }
+        self.state = State::InDocument;
+        Ok(YamEvent::DocStart)
+    }
+
+    pub(crate) fn process_doc(&mut self) -> ControlFlow<Result<YamEvent<'de>, YamlError>> {
+        let ev = match self.parser.next_event_impl() {
+            Ok(ev) => ev.0,
+            Err(err) => return ControlFlow::Break(Err(err)),
+        };
+        match ev {
+            // Ignored events
+            Event::Nothing | Event::Alias(_) | Event::Comment(_) => ControlFlow::Continue(()),
+            // Unexpected events
+            Event::StreamStart => {
+                ControlFlow::Break(Err(YamlError::new_custom("Unexpected Stream start")))
+            }
+            Event::StreamEnd => {
+                ControlFlow::Break(Err(YamlError::new_custom("Unexpected Stream end")))
+            }
+            Event::DocumentStart(_) => {
+                ControlFlow::Break(Err(YamlError::new_custom("Unexpected Document start")))
+            }
+
+            Event::DocumentEnd => {
+                self.state = State::EndDocument;
+                ControlFlow::Break(Ok(YamEvent::DocEnd))
+            }
+
+            Event::Scalar(a) => ControlFlow::Break(Ok(YamEvent::Scalar(a))),
+            Event::SequenceStart(alias, tag) => {
+                ControlFlow::Break(Ok(YamEvent::SeqStart(alias, tag)))
+            }
+            Event::SequenceEnd => ControlFlow::Break(Ok(YamEvent::SeqEnd)),
+            Event::MappingStart(alias, tag) => {
+                ControlFlow::Break(Ok(YamEvent::MapStart(alias, tag)))
+            }
+            Event::MappingEnd => ControlFlow::Break(Ok(YamEvent::MapEnd)),
+        }
+    }
+
+    pub(crate) fn finish_document(&mut self) -> Result<YamEvent<'de>, YamlError> {
+        // Expect a <stream-start>
+        let ev = self.parser.next_event_impl()?.0;
+        if ev != Event::StreamEnd {
+            return Err(YamlError::new_custom("Expected Stream start"));
+        }
+
+        Ok(YamEvent::StreamEnd)
+    }
+}

--- a/yam-core/src/parsing/parser_iter.rs
+++ b/yam-core/src/parsing/parser_iter.rs
@@ -40,7 +40,7 @@ impl<'de, R> ParserIter<'de, R>
 where
     R: Source,
 {
-    fn new(input: R) -> Self {
+    pub fn new(input: R) -> Self {
         Self {
             parser: Parser::new(input),
             state: State::StreamStart,

--- a/yam-core/src/parsing/parser_iter.rs
+++ b/yam-core/src/parsing/parser_iter.rs
@@ -11,7 +11,7 @@ enum State {
     EndDocument,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum YamEvent<'de> {
     DocStart,
     DocEnd,

--- a/yam-core/src/parsing/parser_iter.rs
+++ b/yam-core/src/parsing/parser_iter.rs
@@ -24,6 +24,22 @@ pub enum YamEvent<'de> {
     MapEnd,
 }
 
+impl<'de> YamEvent<'de> {
+    pub fn as_simple_str(&self) -> &'static str {
+        match self {
+            YamEvent::DocStart => "DocStart",
+            YamEvent::DocEnd => "DocEnd",
+            YamEvent::StreamEnd => "StreamStart",
+            YamEvent::Alias(_) => "Alias",
+            YamEvent::Scalar(_) => "Scalar",
+            YamEvent::SeqStart(_, _) => "SeqStart",
+            YamEvent::SeqEnd => "SeqEnd",
+            YamEvent::MapStart(_, _) => "MapStart",
+            YamEvent::MapEnd => "MapEnd",
+        }
+    }
+}
+
 pub struct ParserIter<'de, R: Source> {
     parser: Parser<'de, R>,
     state: State,
@@ -81,12 +97,18 @@ impl<'de, R: Source> ParserIter<'de, R> {
         // Expect a <stream-start>
         let ev = self.parser.next_event_impl()?.0;
         if ev != Event::StreamStart {
-            return Err(YamlError::new_custom("Expected Stream start"));
+            return Err(YamlError::UnExpectedEvent {
+                expected: "StreamStart",
+                found: ev.as_simple_str(),
+            });
         }
         // Expect a <doc-start>
         let ev = self.parser.next_event_impl()?.0;
         if !ev.is_doc_start() {
-            return Err(YamlError::new_custom("Expected Document start"));
+            return Err(YamlError::UnExpectedEvent {
+                expected: "DocStart",
+                found: ev.as_simple_str(),
+            });
         }
         self.state = State::InDocument;
         Ok(YamEvent::DocStart)
@@ -101,15 +123,18 @@ impl<'de, R: Source> ParserIter<'de, R> {
             // Ignored events
             Event::Nothing | Event::Alias(_) | Event::Comment(_) => ControlFlow::Continue(()),
             // Unexpected events
-            Event::StreamStart => {
-                ControlFlow::Break(Err(YamlError::new_custom("Unexpected Stream start")))
-            }
-            Event::StreamEnd => {
-                ControlFlow::Break(Err(YamlError::new_custom("Unexpected Stream end")))
-            }
-            Event::DocumentStart(_) => {
-                ControlFlow::Break(Err(YamlError::new_custom("Unexpected Document start")))
-            }
+            Event::StreamStart => ControlFlow::Break(Err(YamlError::UnExpectedEvent {
+                expected: "StreamStart",
+                found: ev.as_simple_str(),
+            })),
+            Event::StreamEnd => ControlFlow::Break(Err(YamlError::UnExpectedEvent {
+                expected: "StreamEnd",
+                found: ev.as_simple_str(),
+            })),
+            Event::DocumentStart(_) => ControlFlow::Break(Err(YamlError::UnExpectedEvent {
+                expected: "DocumentStart",
+                found: ev.as_simple_str(),
+            })),
 
             Event::DocumentEnd => {
                 self.state = State::EndDocument;
@@ -132,7 +157,10 @@ impl<'de, R: Source> ParserIter<'de, R> {
         // Expect a <stream-start>
         let ev = self.parser.next_event_impl()?.0;
         if ev != Event::StreamEnd {
-            return Err(YamlError::new_custom("Expected Stream start"));
+            return Err(YamlError::UnExpectedEvent {
+                expected: "StreamStart",
+                found: ev.as_simple_str(),
+            });
         }
 
         Ok(YamEvent::StreamEnd)

--- a/yam-core/src/prelude/loader.rs
+++ b/yam-core/src/prelude/loader.rs
@@ -8,7 +8,6 @@ use crate::prelude::{
 use alloc::borrow::Cow;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 
 /// A struct responsible for loading and parsing YAML documents, while maintaining
 /// internal state for tracking document structure and node relationships.
@@ -38,7 +37,6 @@ where
     docs: Vec<Node>,
     doc_stack: Vec<(Node, usize, Option<Cow<'input, Tag>>)>,
     key_stack: Vec<Node>,
-    marker: PhantomData<&'input ()>,
     anchor_map: BTreeMap<usize, Node>,
 }
 
@@ -52,7 +50,6 @@ where
             doc_stack: Vec::new(),
             key_stack: Vec::new(),
             anchor_map: BTreeMap::new(),
-            marker: PhantomData,
         }
     }
 }

--- a/yam-core/src/prelude/mod.rs
+++ b/yam-core/src/prelude/mod.rs
@@ -117,8 +117,10 @@ pub enum YamlError {
     ScannerErr { mark: Marker, info: String },
     /// Expected a document but found none.
     NoDocument,
-    /// Custom error source
-    Custom { info: String },
+    UnExpectedEvent {
+        expected: &'static str,
+        found: &'static str,
+    },
 }
 
 impl Display for YamlError {
@@ -134,7 +136,9 @@ impl Display for YamlError {
                 write!(f, "Scanner error at marker {mark:?}: {info}")
             }
             YamlError::NoDocument => write!(f, "No document found"),
-            YamlError::Custom { info } => write!(f, "{info}"),
+            YamlError::UnExpectedEvent { expected, found } => {
+                write!(f, "Expected event '{expected}' but found '{found}' instead")
+            }
         }
     }
 }
@@ -162,13 +166,6 @@ impl YamlError {
     pub fn new_str(marker: Marker, info: &str) -> Self {
         YamlError::ScannerErr {
             mark: marker,
-            info: info.to_string(),
-        }
-    }
-
-    #[must_use]
-    pub fn new_custom(info: &str) -> Self {
-        YamlError::Custom {
             info: info.to_string(),
         }
     }

--- a/yam-core/src/prelude/mod.rs
+++ b/yam-core/src/prelude/mod.rs
@@ -117,6 +117,8 @@ pub enum YamlError {
     ScannerErr { mark: Marker, info: String },
     /// Expected a document but found none.
     NoDocument,
+    /// Custom error source
+    Custom { info: String },
 }
 
 impl Display for YamlError {
@@ -132,6 +134,7 @@ impl Display for YamlError {
                 write!(f, "Scanner error at marker {mark:?}: {info}")
             }
             YamlError::NoDocument => write!(f, "No document found"),
+            YamlError::Custom { info } => write!(f, "{info}"),
         }
     }
 }
@@ -159,6 +162,13 @@ impl YamlError {
     pub fn new_str(marker: Marker, info: &str) -> Self {
         YamlError::ScannerErr {
             mark: marker,
+            info: info.to_string(),
+        }
+    }
+
+    #[must_use]
+    pub fn new_custom(info: &str) -> Self {
+        YamlError::Custom {
             info: info.to_string(),
         }
     }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -6,7 +6,7 @@ use alloc::format;
 use alloc::string::ToString;
 use core::fmt::{Debug, Display, Formatter};
 use core::i64;
-use serde_core::de::{DeserializeSeed, MapAccess, SeqAccess, StdError};
+use serde_core::de::{DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, StdError};
 use serde_core::{Deserializer, de, forward_to_deserialize_any};
 use yam_core::node::YamlScalar;
 use yam_core::parsing::parser_iter::YamEvent;
@@ -89,11 +89,7 @@ where
     where
         V: de::Visitor<'de>,
     {
-        match self.next_el() {
-            Some(YamEvent::DocStart) => {
-                self.skip();
-                DocSerializer::new(self).deserialize_any(visitor)
-            }
+        match self.skip_doc() {
             Some(YamEvent::MapStart(_, _)) => visitor.visit_map(MapCollection::new(self)),
             Some(YamEvent::SeqStart(_, _)) => visitor.visit_seq(SeqCollection::new(self)),
             Some(YamEvent::Scalar(scalr)) => {
@@ -218,10 +214,24 @@ where
         }
     }
 
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(DeYamlError(YamlError::Custom {
+            info: "Enum deserialization not supported".to_string(),
+        }))
+    }
+
     forward_to_deserialize_any! {
         bool i128 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
+        tuple_struct map struct identifier ignored_any
     }
 }
 
@@ -268,133 +278,6 @@ impl de::Error for DeYamlError {
     {
         let info = format!("{}", msg);
         DeYamlError(YamlError::Custom { info })
-    }
-}
-
-struct DocSerializer<'a, 'de, R>
-where
-    R: Source,
-    'de: 'a,
-{
-    deserializer: &'a mut YamlIterDeserializer<'de, R>,
-}
-
-impl<'a, 'de, R> DocSerializer<'a, 'de, R>
-where
-    R: Source,
-    'de: 'a,
-{
-    fn new(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
-        DocSerializer { deserializer: iter }
-    }
-
-    fn resolve_scalar<V: de::Visitor<'de>>(
-        &mut self,
-        scalar_value: ScalarValue,
-        visitor: V,
-    ) -> Result<V::Value, DeYamlError> {
-        self.deserializer.resolve_scalar(scalar_value, visitor)
-    }
-}
-
-impl<'a, 'de, R> DocSerializer<'a, 'de, R>
-where
-    R: Source,
-    'de: 'a,
-{
-    fn serialize_any<V>(
-        &'a mut self,
-        visitor: V,
-        event: YamEvent<'de>,
-    ) -> Result<V::Value, DeYamlError>
-    where
-        V: de::Visitor<'de>,
-    {
-        match event {
-            YamEvent::Scalar(scalar_value) => self.resolve_scalar(scalar_value, visitor),
-            YamEvent::MapStart(_, _) => self.deserialize_map(visitor),
-            YamEvent::SeqStart(_, _) => self.deserialize_seq(visitor),
-            e => Err(DeYamlError(YamlError::Custom {
-                info: format!("Unexpected event in serialize: {:?}", e),
-            })),
-        }
-    }
-}
-
-impl<'a, 'de, R> Deserializer<'de> for &'a mut DocSerializer<'a, 'de, R>
-where
-    R: Source,
-    'de: 'a,
-{
-    type Error = DeYamlError;
-    // Look at the input data to decide what Serde data model type to
-    // deserialize as. Not all data formats are able to support this operation.
-    // Formats that support `deserialize_any` are known as self-describing.
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: de::Visitor<'de>,
-    {
-        match self.deserializer.next_el() {
-            Some(ev) => self.serialize_any(visitor, ev),
-            e => Err(DeYamlError(YamlError::Custom {
-                info: format!("Unexpected event: {:?}", e),
-            })),
-        }
-    }
-
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: de::Visitor<'de>,
-    {
-        if !matches!(self.deserializer.last_event, YamEvent::SeqStart(_, _)) {
-            return Err(DeYamlError(YamlError::Custom {
-                info: format!(
-                    "Expected SeqStart event, found {:?}",
-                    self.deserializer.last_event
-                ),
-            }));
-        }
-        let value = visitor.visit_seq(SeqCollection::new(self.deserializer))?;
-        match self.deserializer.last_event {
-            YamEvent::SeqEnd => Ok(value),
-            _ => Err(DeYamlError(YamlError::Custom {
-                info: format!(
-                    "Expected SeqEnd event, found {:?}",
-                    self.deserializer.last_event
-                ),
-            })),
-        }
-    }
-
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: de::Visitor<'de>,
-    {
-        if !matches!(self.deserializer.last_event, YamEvent::MapStart(_, _)) {
-            return Err(DeYamlError(YamlError::Custom {
-                info: format!(
-                    "Expected MapStart event, found {:?}",
-                    self.deserializer.last_event
-                ),
-            }));
-        }
-        self.deserializer.skip();
-        let value = visitor.visit_map(MapCollection::new(self.deserializer))?;
-        match self.deserializer.last_event {
-            YamEvent::MapEnd => Ok(value),
-            _ => Err(DeYamlError(YamlError::Custom {
-                info: format!(
-                    "Expected MapEnd event, found {:?}",
-                    self.deserializer.last_event
-                ),
-            })),
-        }
-    }
-
-    forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct  tuple
-        tuple_struct struct enum identifier ignored_any
     }
 }
 
@@ -479,5 +362,22 @@ where
             }
             Some(_) => seed.deserialize(&mut *self.iter).map(Some),
         }
+    }
+}
+
+struct Enum<'a, 'de: 'a, R>
+where
+    R: Source,
+{
+    de: &'a mut YamlIterDeserializer<'de, R>,
+}
+
+impl<'a, 'de, R> Enum<'a, 'de, R>
+where
+    'de: 'a,
+    R: Source,
+{
+    fn new(de: &'a mut YamlIterDeserializer<'de, R>) -> Self {
+        Enum { de }
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -94,6 +94,12 @@ where
                 self.skip();
                 DocSerializer::new(self).deserialize_any(visitor)
             }
+            Some(YamEvent::MapStart(_, _)) => visitor.visit_map(MapCollection::new(self)),
+            Some(YamEvent::SeqStart(_, _)) => visitor.visit_seq(SeqCollection::new(self)),
+            Some(YamEvent::Scalar(scalr)) => {
+                self.skip();
+                self.resolve_scalar(scalr, visitor)
+            }
             e => Err(DeYamlError(YamlError::Custom {
                 info: format!("Unexpected event (can only process DocStart): {:?}", e),
             })),
@@ -372,6 +378,7 @@ where
                 ),
             }));
         }
+        self.deserializer.skip();
         let value = visitor.visit_map(MapCollection::new(self.deserializer))?;
         match self.deserializer.last_event {
             YamEvent::MapEnd => Ok(value),
@@ -432,7 +439,8 @@ where
     where
         V: DeserializeSeed<'de>,
     {
-        seed.deserialize(&mut *self.iter)
+        let val = seed.deserialize(&mut *self.iter)?;
+        Ok(val)
     }
 }
 

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -231,7 +231,9 @@ where
         }
         self.skip();
         let val = visitor.visit_seq(SeqCollection::new_seq(self))?;
-        if !matches!(self.last_event, YamEvent::SeqEnd) {
+        if !matches!(self.last_event, YamEvent::SeqEnd)
+            && !matches!(self.next_el(), Some(YamEvent::SeqEnd))
+        {
             return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
                 expected: "SeqEnd",
                 found: self.last_event.as_simple_str(),
@@ -253,7 +255,9 @@ where
         }
         self.skip();
         let val = visitor.visit_map(SeqCollection::new_map(self))?;
-        if !matches!(self.last_event, YamEvent::MapEnd) {
+        if !matches!(self.last_event, YamEvent::MapEnd)
+            && !matches!(self.next_el(), Some(YamEvent::MapEnd))
+        {
             return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
                 expected: "MapEnd",
                 found: self.last_event.as_simple_str(),
@@ -394,10 +398,7 @@ where
         T: DeserializeSeed<'de>,
     {
         match self.iter.next_el() {
-            Some(YamEvent::SeqEnd) => {
-                self.iter.skip();
-                Ok(None)
-            }
+            Some(YamEvent::SeqEnd) => Ok(None),
             Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
                 Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
                     expected: "SeqEnd",

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -5,12 +5,12 @@ extern crate alloc;
 use alloc::format;
 use alloc::string::{String, ToString};
 use core::fmt::{Debug, Display, Formatter};
-use core::i64;
+
 use serde_core::de::{
     DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, StdError, VariantAccess,
     Visitor,
 };
-use serde_core::{Deserializer, de, forward_to_deserialize_any};
+use serde_core::{de, forward_to_deserialize_any};
 use yam_core::node::YamlScalar;
 use yam_core::parsing::parser_iter::YamEvent;
 use yam_core::parsing::{ParserIter, ScalarValue, StrSource};
@@ -83,7 +83,7 @@ macro_rules! parse_from_cow {
     };
 }
 
-impl<'a, 'de, R> Deserializer<'de> for &'a mut YamlIterDeserializer<'de, R>
+impl<'a, 'de, R> de::Deserializer<'de> for &'a mut YamlIterDeserializer<'de, R>
 where
     R: Source,
 {
@@ -94,8 +94,8 @@ where
         V: de::Visitor<'de>,
     {
         match self.skip_doc() {
-            Some(YamEvent::MapStart(_, _)) => visitor.visit_map(MapCollection::new(self)),
-            Some(YamEvent::SeqStart(_, _)) => visitor.visit_seq(SeqCollection::new(self)),
+            Some(YamEvent::MapStart(_, _)) => self.deserialize_map(visitor),
+            Some(YamEvent::SeqStart(_, _)) => self.deserialize_seq(visitor),
             Some(YamEvent::Scalar(scalr)) => {
                 self.skip();
                 self.resolve_scalar(scalr, visitor)
@@ -219,6 +219,56 @@ where
         }
     }
 
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if !matches!(self.skip_doc(), Some(YamEvent::SeqStart(_, _))) {
+            return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                expected: "SeqStart",
+                found: self.last_event.as_simple_str(),
+            }));
+        }
+        self.skip();
+        let val = visitor.visit_seq(SeqCollection::new_seq(self))?;
+        if !matches!(self.last_event, YamEvent::SeqEnd) {
+            return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                expected: "SeqEnd",
+                found: self.last_event.as_simple_str(),
+            }));
+        }
+        self.skip();
+        Ok(val)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if !matches!(self.skip_doc(), Some(YamEvent::MapStart(_, _))) {
+            return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                expected: "MapStart",
+                found: self.last_event.as_simple_str(),
+            }));
+        }
+        self.skip();
+        let val = visitor.visit_map(SeqCollection::new_map(self))?;
+        if !matches!(self.last_event, YamEvent::MapEnd) {
+            return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                expected: "MapEnd",
+                found: self.last_event.as_simple_str(),
+            }));
+        }
+        self.skip();
+        Ok(val)
+    }
+
+    forward_to_deserialize_any! {
+        bool i128 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct tuple
+        tuple_struct struct ignored_any
+    }
+
     fn deserialize_enum<V>(
         self,
         _name: &'static str,
@@ -233,9 +283,19 @@ where
                 self.skip();
                 visitor.visit_enum(value.into_deserializer())
             }
-            _ => Err(DeYamlError::Custom(
-                "Expected scalar event for enum deserialization".to_string(),
-            )),
+            Some(YamEvent::MapStart(_, _)) => {
+                self.skip();
+                let value = visitor.visit_enum(Enum::new(self))?;
+
+                if !matches!(self.next_el(), Some(YamEvent::MapEnd)) {
+                    return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                        found: self.last_event.as_simple_str(),
+                        expected: "MapEnd",
+                    }));
+                }
+                Ok(value)
+            }
+            _ => Err(DeYamlError::Custom("Expected enum".to_string())),
         }
     }
 
@@ -244,12 +304,6 @@ where
         V: de::Visitor<'de>,
     {
         self.deserialize_str(visitor)
-    }
-
-    forward_to_deserialize_any! {
-        bool i128 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct ignored_any
     }
 }
 
@@ -282,6 +336,7 @@ where
 pub enum DeYamlError {
     ParserError(YamlError),
     Custom(String),
+    ExpectedStringInNewType,
 }
 
 impl StdError for DeYamlError {}
@@ -291,6 +346,7 @@ impl Display for DeYamlError {
         match self {
             DeYamlError::ParserError(err) => write!(f, "ParserError: {}", err)?,
             DeYamlError::Custom(msg) => write!(f, "Custom: {}", msg)?,
+            DeYamlError::ExpectedStringInNewType => write!(f, "Expected String:")?,
         };
         Ok(())
     }
@@ -306,23 +362,54 @@ impl de::Error for DeYamlError {
     }
 }
 
-struct MapCollection<'a, 'de: 'a, R>
+struct SeqCollection<'a, 'de: 'a, R>
 where
     R: Source,
 {
     iter: &'a mut YamlIterDeserializer<'de, R>,
+    map: bool,
 }
 
-impl<'a, 'de, R> MapCollection<'a, 'de, R>
+impl<'a, 'de, R> SeqCollection<'a, 'de, R>
 where
     R: Source,
 {
-    fn new(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
-        MapCollection { iter }
+    fn new_seq(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
+        SeqCollection { iter, map: false }
+    }
+
+    fn new_map(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
+        SeqCollection { iter, map: true }
     }
 }
 
-impl<'de, 'a, R> MapAccess<'de> for MapCollection<'a, 'de, R>
+impl<'de, 'a, R> SeqAccess<'de> for SeqCollection<'a, 'de, R>
+where
+    R: Source,
+{
+    type Error = DeYamlError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next_el() {
+            Some(YamEvent::SeqEnd) => {
+                self.iter.skip();
+                Ok(None)
+            }
+            Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
+                Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                    expected: "SeqEnd",
+                    found: self.iter.last_event.as_simple_str(),
+                }))
+            }
+            Some(_) => seed.deserialize(&mut *self.iter).map(Some),
+        }
+    }
+}
+
+impl<'de, 'a, R> MapAccess<'de> for SeqCollection<'a, 'de, R>
 where
     R: Source,
 {
@@ -351,60 +438,6 @@ where
         // TODO
         let val = seed.deserialize(&mut *self.iter)?;
         Ok(val)
-    }
-}
-
-struct SeqCollection<'a, 'de: 'a, R>
-where
-    R: Source,
-{
-    iter: &'a mut YamlIterDeserializer<'de, R>,
-    first: bool,
-}
-
-impl<'a, 'de, R> SeqCollection<'a, 'de, R>
-where
-    R: Source,
-{
-    fn new(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
-        SeqCollection { iter, first: true }
-    }
-}
-
-impl<'de, 'a, R> SeqAccess<'de> for SeqCollection<'a, 'de, R>
-where
-    R: Source,
-{
-    type Error = DeYamlError;
-
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        if self.first {
-            self.first = false;
-            if !matches!(self.iter.last_event, YamEvent::SeqStart(_, _)) {
-                return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
-                    expected: "SeqStart",
-                    found: self.iter.last_event.as_simple_str(),
-                }));
-            }
-            self.iter.skip();
-        }
-
-        match self.iter.next_el() {
-            Some(YamEvent::SeqEnd) => {
-                self.iter.skip();
-                Ok(None)
-            }
-            Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
-                Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
-                    expected: "SeqEnd",
-                    found: self.iter.last_event.as_simple_str(),
-                }))
-            }
-            Some(_) => seed.deserialize(&mut *self.iter).map(Some),
-        }
     }
 }
 
@@ -457,14 +490,14 @@ where
     where
         T: DeserializeSeed<'de>,
     {
-        todo!()
+        seed.deserialize(&mut *self.de)
     }
 
     fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        V: de::Visitor<'de>,
     {
-        todo!()
+        de::Deserializer::deserialize_seq(&mut *self.de, visitor)
     }
 
     fn struct_variant<V>(
@@ -473,8 +506,8 @@ where
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        V: de::Visitor<'de>,
     {
-        todo!()
+        de::Deserializer::deserialize_map(&mut *self.de, visitor)
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -5,7 +5,7 @@ use alloc::collections::BTreeMap;
 use alloc::format;
 use core::fmt::{Debug, Display, Formatter};
 use serde_core::de::StdError;
-use serde_core::{Deserializer, de};
+use serde_core::{Deserializer, de, forward_to_deserialize_any};
 use yam_core::LazyExpander;
 use yam_core::parsing::ParserIter;
 use yam_core::parsing::parser_iter::YamEvent;
@@ -40,7 +40,18 @@ impl de::Error for DeYamlError {
     }
 }
 
-impl<'de, R, V> Deserializer<'de> for &'de mut YamlIterDeserializer<'de, R, V> {
+impl<'de, R> YamlIterDeserializer<'de, R>
+where
+    R: Source,
+{
+    fn resolve_scalar<V: de::Visitor<'de>>(&mut self, visitor: V) -> Result<V::Value, DeYamlError> {
+    }
+}
+
+impl<'de, R> Deserializer<'de> for &'de mut YamlIterDeserializer<'de, R>
+where
+    R: Source,
+{
     type Error = DeYamlError;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -48,17 +59,20 @@ impl<'de, R, V> Deserializer<'de> for &'de mut YamlIterDeserializer<'de, R, V> {
         V: de::Visitor<'de>,
     {
         for x in self.yaml_iter {
+            let info = format!("Didn't expect to see: {:?}", x);
             match x {
                 YamEvent::DocStart => {}
-                YamEvent::DocEnd => {}
-                YamEvent::StreamEnd => {}
-                YamEvent::Alias(_) => {}
-                YamEvent::Scalar(_) => {}
+                YamEvent::Scalar(scalar) => {}
                 YamEvent::SeqStart(_, _) => {}
-                YamEvent::SeqEnd => {}
                 YamEvent::MapStart(_, _) => {}
-                YamEvent::MapEnd => {}
+                _ => Err(DeYamlError(YamlError::Custom { info })),
             }
         }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -2,12 +2,10 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
 use alloc::format;
 use core::fmt::{Debug, Display, Formatter};
 use serde_core::de::StdError;
 use serde_core::{Deserializer, de, forward_to_deserialize_any};
-use yam_core::LazyExpander;
 use yam_core::node::YamlScalar;
 use yam_core::parsing::parser_iter::YamEvent;
 use yam_core::parsing::{ParserIter, ScalarValue, StrSource};
@@ -16,18 +14,40 @@ use yam_core::prelude::{Source, YamlError};
 struct YamlIterDeserializer<'de, R>
 where
     R: Source,
-    R: 'de,
 {
     yaml_iter: ParserIter<'de, R>,
-    alias: BTreeMap<usize, LazyExpander<'de>>,
 }
 
 impl<'a> YamlIterDeserializer<'a, StrSource<'a>> {
     pub fn new(source: &'a str) -> Self {
         YamlIterDeserializer {
             yaml_iter: ParserIter::new(StrSource::new(source)),
-            alias: BTreeMap::new(),
         }
+    }
+}
+
+impl<'a, 'de, R> Deserializer<'de> for &'a mut YamlIterDeserializer<'de, R>
+where
+    R: Source,
+{
+    type Error = DeYamlError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.yaml_iter.next() {
+            Some(YamEvent::DocStart) => DocSerializer::new(self).deserialize_any(visitor),
+            e => Err(DeYamlError(YamlError::Custom {
+                info: format!("Unexpected event (can only process DocStart: {:?}", e),
+            })),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
     }
 }
 
@@ -42,7 +62,7 @@ where
 }
 
 #[derive(Debug)]
-struct DeYamlError(YamlError);
+pub struct DeYamlError(YamlError);
 
 impl StdError for DeYamlError {}
 
@@ -62,10 +82,23 @@ impl de::Error for DeYamlError {
     }
 }
 
-impl<'de, R> YamlIterDeserializer<'de, R>
+struct DocSerializer<'a, 'de, R>
 where
     R: Source,
+    'de: 'a,
 {
+    deserializer: &'a mut YamlIterDeserializer<'de, R>,
+}
+
+impl<'a, 'de, R> DocSerializer<'a, 'de, R>
+where
+    R: Source,
+    'de: 'a,
+{
+    fn new(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
+        DocSerializer { deserializer: iter }
+    }
+
     fn resolve_scalar<V: de::Visitor<'de>>(
         &mut self,
         scalar_value: ScalarValue,
@@ -73,6 +106,7 @@ where
     ) -> Result<V::Value, DeYamlError> {
         let scalar = YamlScalar::parse_from_scalar(scalar_value);
         match scalar {
+            Some(YamlScalar::Integer(x)) if x > 0 => visitor.visit_u64(x as u64),
             Some(YamlScalar::Integer(x)) => visitor.visit_i64(x),
             Some(YamlScalar::FloatingPoint(x)) => visitor.visit_f64(x),
             Some(YamlScalar::Bool(x)) => visitor.visit_bool(x),
@@ -83,23 +117,25 @@ where
     }
 }
 
-impl<'de, 'a, R> Deserializer<'de> for &'a mut YamlIterDeserializer<'de, R>
+impl<'a, 'de, R> Deserializer<'de> for &'a mut DocSerializer<'a, 'de, R>
 where
     R: Source,
+    'de: 'a,
 {
     type Error = DeYamlError;
-
+    // Look at the input data to decide what Serde data model type to
+    // deserialize as. Not all data formats are able to support this operation.
+    // Formats that support `deserialize_any` are known as self-describing.
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        match self.yaml_iter.next() {
-            Some(YamEvent::Scalar(scalar)) => self.resolve_scalar(scalar, visitor),
-            Some(ev) => {
-                let info = format!("Didn't expect to see: {:?}", ev);
-                Err(DeYamlError(YamlError::Custom { info }))
-            }
-            None => Err(DeYamlError(YamlError::new_custom("Unexpected end"))),
+        match self.deserializer.yaml_iter.next() {
+            Some(YamEvent::Scalar(scalar_value)) => self.resolve_scalar(scalar_value, visitor),
+
+            e => Err(DeYamlError(YamlError::Custom {
+                info: format!("Unexpected event: {:?}", e),
+            })),
         }
     }
 

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+
 extern crate alloc;
 
 use alloc::collections::BTreeMap;
@@ -7,16 +8,37 @@ use core::fmt::{Debug, Display, Formatter};
 use serde_core::de::StdError;
 use serde_core::{Deserializer, de, forward_to_deserialize_any};
 use yam_core::LazyExpander;
-use yam_core::parsing::ParserIter;
+use yam_core::node::YamlScalar;
 use yam_core::parsing::parser_iter::YamEvent;
+use yam_core::parsing::{ParserIter, ScalarValue, StrSource};
 use yam_core::prelude::{Source, YamlError};
 
 struct YamlIterDeserializer<'de, R>
 where
     R: Source,
+    R: 'de,
 {
     yaml_iter: ParserIter<'de, R>,
     alias: BTreeMap<usize, LazyExpander<'de>>,
+}
+
+impl<'a> YamlIterDeserializer<'a, StrSource<'a>> {
+    pub fn new(source: &'a str) -> Self {
+        YamlIterDeserializer {
+            yaml_iter: ParserIter::new(StrSource::new(source)),
+            alias: BTreeMap::new(),
+        }
+    }
+}
+
+pub fn from_str<'a, T>(input: &'a str) -> Result<T, DeYamlError>
+where
+    T: de::Deserialize<'a>,
+{
+    let mut de = YamlIterDeserializer::new(input);
+    let value = T::deserialize(&mut de)?;
+
+    Ok(value)
 }
 
 #[derive(Debug)]
@@ -44,11 +66,24 @@ impl<'de, R> YamlIterDeserializer<'de, R>
 where
     R: Source,
 {
-    fn resolve_scalar<V: de::Visitor<'de>>(&mut self, visitor: V) -> Result<V::Value, DeYamlError> {
+    fn resolve_scalar<V: de::Visitor<'de>>(
+        &mut self,
+        scalar_value: ScalarValue,
+        visitor: V,
+    ) -> Result<V::Value, DeYamlError> {
+        let scalar = YamlScalar::parse_from_scalar(scalar_value);
+        match scalar {
+            Some(YamlScalar::Integer(x)) => visitor.visit_i64(x),
+            Some(YamlScalar::FloatingPoint(x)) => visitor.visit_f64(x),
+            Some(YamlScalar::Bool(x)) => visitor.visit_bool(x),
+            Some(YamlScalar::String(x)) => visitor.visit_str(&x),
+            Some(YamlScalar::Null(_)) => visitor.visit_none(),
+            None => Err(DeYamlError(YamlError::new_custom("Failed to parse scalar"))),
+        }
     }
 }
 
-impl<'de, R> Deserializer<'de> for &'de mut YamlIterDeserializer<'de, R>
+impl<'de, 'a, R> Deserializer<'de> for &'a mut YamlIterDeserializer<'de, R>
 where
     R: Source,
 {
@@ -58,15 +93,13 @@ where
     where
         V: de::Visitor<'de>,
     {
-        for x in self.yaml_iter {
-            let info = format!("Didn't expect to see: {:?}", x);
-            match x {
-                YamEvent::DocStart => {}
-                YamEvent::Scalar(scalar) => {}
-                YamEvent::SeqStart(_, _) => {}
-                YamEvent::MapStart(_, _) => {}
-                _ => Err(DeYamlError(YamlError::Custom { info })),
+        match self.yaml_iter.next() {
+            Some(YamEvent::Scalar(scalar)) => self.resolve_scalar(scalar, visitor),
+            Some(ev) => {
+                let info = format!("Didn't expect to see: {:?}", ev);
+                Err(DeYamlError(YamlError::Custom { info }))
             }
+            None => Err(DeYamlError(YamlError::new_custom("Unexpected end"))),
         }
     }
 

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -5,9 +5,10 @@ extern crate alloc;
 use alloc::format;
 use alloc::string::ToString;
 use core::fmt::{Debug, Display, Formatter};
+use core::i64;
 use serde_core::de::{DeserializeSeed, MapAccess, SeqAccess, StdError};
 use serde_core::{Deserializer, de, forward_to_deserialize_any};
-use yam_core::node::{YamlScalar, parse_i64_from_cow};
+use yam_core::node::YamlScalar;
 use yam_core::parsing::parser_iter::YamEvent;
 use yam_core::parsing::{ParserIter, ScalarValue, StrSource};
 use yam_core::prelude::{Source, YamlError};
@@ -17,16 +18,16 @@ where
     R: Source,
 {
     yaml_iter: ParserIter<'de, R>,
-    peek_event: YamEvent<'de>,
-    is_peeked: bool,
+    last_event: YamEvent<'de>,
+    has_peeked: bool,
 }
 
 impl<'a> YamlIterDeserializer<'a, StrSource<'a>> {
     pub fn new(source: &'a str) -> Self {
         YamlIterDeserializer {
             yaml_iter: ParserIter::new(StrSource::new(source)),
-            peek_event: YamEvent::DocStart,
-            is_peeked: false,
+            last_event: YamEvent::DocStart,
+            has_peeked: false,
         }
     }
 }
@@ -36,14 +37,18 @@ where
     R: Source,
 {
     fn next_el(&mut self) -> Option<YamEvent<'a>> {
-        if self.is_peeked {
-            self.is_peeked = false;
-            return Some(self.peek_event.clone());
+        if self.has_peeked {
+            self.has_peeked = false;
+            return Some(self.last_event.clone());
         }
 
-        self.is_peeked = true;
-        self.peek_event = self.yaml_iter.next()?;
-        Some(self.peek_event.clone())
+        self.has_peeked = true;
+        self.last_event = self.yaml_iter.next()?;
+        Some(self.last_event.clone())
+    }
+
+    fn skip(&mut self) {
+        self.has_peeked = false;
     }
 
     fn resolve_scalar<V: de::Visitor<'a>>(
@@ -63,6 +68,17 @@ where
     }
 }
 
+macro_rules! parse_from_cow {
+    ($e:expr, $v:expr, $method:ident, $t:ty) => {
+        match $e.parse::<$t>() {
+            Ok(i) => $v.$method(i),
+            Err(_) => Err(DeYamlError(YamlError::Custom {
+                info: format!("Failed to parse {:?} from scalar value", stringify!($t)),
+            })),
+        }
+    };
+}
+
 impl<'a, 'de, R> Deserializer<'de> for &'a mut YamlIterDeserializer<'de, R>
 where
     R: Source,
@@ -75,7 +91,7 @@ where
     {
         match self.next_el() {
             Some(YamEvent::DocStart) => {
-                self.is_peeked = false;
+                self.skip();
                 DocSerializer::new(self).deserialize_any(visitor)
             }
             e => Err(DeYamlError(YamlError::Custom {
@@ -84,18 +100,41 @@ where
         }
     }
 
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc() {
+            self.has_peeked = false;
+            parse_from_cow!(&scalar.value, visitor, visit_i8, i8)
+        } else {
+            Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for i32 deserialization".to_string(),
+            }))
+        }
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc() {
+            self.has_peeked = false;
+            parse_from_cow!(&scalar.value, visitor, visit_i16, i16)
+        } else {
+            Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for i16 deserialization".to_string(),
+            }))
+        }
+    }
+
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        if let Some(YamEvent::Scalar(scalar)) = self.next_el() {
-            self.is_peeked = false;
-            match parse_i64_from_cow(&scalar.value) {
-                Ok(int) => visitor.visit_i32(int as i32),
-                Err(_) => Err(DeYamlError(YamlError::Custom {
-                    info: "Failed to parse i32 from scalar value".to_string(),
-                })),
-            }
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc() {
+            self.skip();
+            parse_from_cow!(&scalar.value, visitor, visit_i32, i32)
         } else {
             Err(DeYamlError(YamlError::Custom {
                 info: "Expected scalar event for i32 deserialization".to_string(),
@@ -107,25 +146,91 @@ where
     where
         V: de::Visitor<'de>,
     {
-        if let Some(YamEvent::Scalar(scalar)) = self.next_el() {
-            self.is_peeked = false;
-            match parse_i64_from_cow(&scalar.value) {
-                Ok(int) => visitor.visit_i64(int),
-                Err(_) => Err(DeYamlError(YamlError::Custom {
-                    info: "Failed to parse i32 from scalar value".to_string(),
-                })),
-            }
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc() {
+            self.skip();
+            parse_from_cow!(&scalar.value, visitor, visit_i64, i64)
         } else {
             Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for i32 deserialization".to_string(),
+                info: "Expected scalar event for i64 deserialization".to_string(),
+            }))
+        }
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc() {
+            self.has_peeked = false;
+            parse_from_cow!(&scalar.value, visitor, visit_u8, u8)
+        } else {
+            Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for u8 deserialization".to_string(),
+            }))
+        }
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc() {
+            self.has_peeked = false;
+            parse_from_cow!(&scalar.value, visitor, visit_u16, u16)
+        } else {
+            Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for u16 deserialization".to_string(),
+            }))
+        }
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc() {
+            self.skip();
+            parse_from_cow!(&scalar.value, visitor, visit_u32, u32)
+        } else {
+            Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for u32 deserialization".to_string(),
+            }))
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc() {
+            self.skip();
+            parse_from_cow!(&scalar.value, visitor, visit_u64, u64)
+        } else {
+            Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for u64 deserialization".to_string(),
             }))
         }
     }
 
     forward_to_deserialize_any! {
-        bool i8 i16 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bool i128 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+impl<'de, R> YamlIterDeserializer<'de, R>
+where
+    R: Source,
+{
+    fn skip_doc<'a>(&'a mut self) -> Option<YamEvent<'de>> {
+        match self.next_el() {
+            Some(YamEvent::DocStart) => {
+                self.skip();
+                self.next_el()
+            }
+            ev => ev,
+        }
     }
 }
 
@@ -235,21 +340,21 @@ where
     where
         V: de::Visitor<'de>,
     {
-        if !matches!(self.deserializer.peek_event, YamEvent::SeqStart(_, _)) {
+        if !matches!(self.deserializer.last_event, YamEvent::SeqStart(_, _)) {
             return Err(DeYamlError(YamlError::Custom {
                 info: format!(
                     "Expected SeqStart event, found {:?}",
-                    self.deserializer.peek_event
+                    self.deserializer.last_event
                 ),
             }));
         }
         let value = visitor.visit_seq(SeqCollection::new(self.deserializer))?;
-        match self.deserializer.peek_event {
+        match self.deserializer.last_event {
             YamEvent::SeqEnd => Ok(value),
             _ => Err(DeYamlError(YamlError::Custom {
                 info: format!(
                     "Expected SeqEnd event, found {:?}",
-                    self.deserializer.peek_event
+                    self.deserializer.last_event
                 ),
             })),
         }
@@ -259,21 +364,21 @@ where
     where
         V: de::Visitor<'de>,
     {
-        if !matches!(self.deserializer.peek_event, YamEvent::MapStart(_, _)) {
+        if !matches!(self.deserializer.last_event, YamEvent::MapStart(_, _)) {
             return Err(DeYamlError(YamlError::Custom {
                 info: format!(
                     "Expected MapStart event, found {:?}",
-                    self.deserializer.peek_event
+                    self.deserializer.last_event
                 ),
             }));
         }
         let value = visitor.visit_map(MapCollection::new(self.deserializer))?;
-        match self.deserializer.peek_event {
+        match self.deserializer.last_event {
             YamEvent::MapEnd => Ok(value),
             _ => Err(DeYamlError(YamlError::Custom {
                 info: format!(
                     "Expected MapEnd event, found {:?}",
-                    self.deserializer.peek_event
+                    self.deserializer.last_event
                 ),
             })),
         }
@@ -316,7 +421,7 @@ where
             Some(YamEvent::MapEnd) => Ok(None),
             Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
                 Err(DeYamlError(YamlError::Custom {
-                    info: format!("Expected map key, found {:?}", self.iter.peek_event),
+                    info: format!("Expected map key, found {:?}", self.iter.last_event),
                 }))
             }
             Some(_) => seed.deserialize(&mut *self.iter).map(Some),
@@ -361,7 +466,7 @@ where
             Some(YamEvent::SeqEnd) => Ok(None),
             Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
                 Err(DeYamlError(YamlError::Custom {
-                    info: format!("Expected seq, found {:?}", self.iter.peek_event),
+                    info: format!("Expected seq, found {:?}", self.iter.last_event),
                 }))
             }
             Some(_) => seed.deserialize(&mut *self.iter).map(Some),

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -3,8 +3,9 @@
 extern crate alloc;
 
 use alloc::format;
+
 use core::fmt::{Debug, Display, Formatter};
-use serde_core::de::StdError;
+use serde_core::de::{DeserializeSeed, MapAccess, SeqAccess, StdError};
 use serde_core::{Deserializer, de, forward_to_deserialize_any};
 use yam_core::node::YamlScalar;
 use yam_core::parsing::parser_iter::YamEvent;
@@ -16,12 +17,29 @@ where
     R: Source,
 {
     yaml_iter: ParserIter<'de, R>,
+    peek_event: YamEvent<'de>,
 }
 
 impl<'a> YamlIterDeserializer<'a, StrSource<'a>> {
     pub fn new(source: &'a str) -> Self {
         YamlIterDeserializer {
             yaml_iter: ParserIter::new(StrSource::new(source)),
+            peek_event: YamEvent::DocStart,
+        }
+    }
+}
+
+impl<'a, R> YamlIterDeserializer<'a, R>
+where
+    R: Source,
+{
+    fn next_el(&mut self) -> Option<YamEvent<'a>> {
+        match self.yaml_iter.next() {
+            Some(x) => {
+                self.peek_event = x.clone();
+                Some(x)
+            }
+            None => None,
         }
     }
 }
@@ -106,13 +124,36 @@ where
     ) -> Result<V::Value, DeYamlError> {
         let scalar = YamlScalar::parse_from_scalar(scalar_value);
         match scalar {
-            Some(YamlScalar::Integer(x)) if x > 0 => visitor.visit_u64(x as u64),
             Some(YamlScalar::Integer(x)) => visitor.visit_i64(x),
             Some(YamlScalar::FloatingPoint(x)) => visitor.visit_f64(x),
             Some(YamlScalar::Bool(x)) => visitor.visit_bool(x),
             Some(YamlScalar::String(x)) => visitor.visit_str(&x),
-            Some(YamlScalar::Null(_)) => visitor.visit_none(),
+            Some(YamlScalar::Null(_)) => visitor.visit_unit(),
             None => Err(DeYamlError(YamlError::new_custom("Failed to parse scalar"))),
+        }
+    }
+}
+
+impl<'a, 'de, R> DocSerializer<'a, 'de, R>
+where
+    R: Source,
+    'de: 'a,
+{
+    fn serialize_any<V>(
+        &'a mut self,
+        visitor: V,
+        event: YamEvent<'de>,
+    ) -> Result<V::Value, DeYamlError>
+    where
+        V: de::Visitor<'de>,
+    {
+        match event {
+            YamEvent::Scalar(scalar_value) => self.resolve_scalar(scalar_value, visitor),
+            YamEvent::MapStart(_, _) => self.deserialize_map(visitor),
+            YamEvent::SeqStart(_, _) => self.deserialize_seq(visitor),
+            e => Err(DeYamlError(YamlError::Custom {
+                info: format!("Unexpected event: {:?}", e),
+            })),
         }
     }
 }
@@ -130,18 +171,132 @@ where
     where
         V: de::Visitor<'de>,
     {
-        match self.deserializer.yaml_iter.next() {
-            Some(YamEvent::Scalar(scalar_value)) => self.resolve_scalar(scalar_value, visitor),
-
+        match self.deserializer.next_el() {
+            Some(ev) => self.serialize_any(visitor, ev),
             e => Err(DeYamlError(YamlError::Custom {
                 info: format!("Unexpected event: {:?}", e),
             })),
         }
     }
 
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if !matches!(self.deserializer.peek_event, YamEvent::MapStart(_, _)) {
+            return Err(DeYamlError(YamlError::Custom {
+                info: format!(
+                    "Expected MapStart event, found {:?}",
+                    self.deserializer.peek_event
+                ),
+            }));
+        }
+        let value = visitor.visit_map(MapCollection::new(self.deserializer))?;
+        match self.deserializer.next_el() {
+            Some(YamEvent::MapEnd) => Ok(value),
+            _ => Err(DeYamlError(YamlError::Custom {
+                info: format!(
+                    "Expected MapEnd event, found {:?}",
+                    self.deserializer.peek_event
+                ),
+            })),
+        }
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if !matches!(self.deserializer.peek_event, YamEvent::SeqStart(_, _)) {
+            return Err(DeYamlError(YamlError::Custom {
+                info: format!(
+                    "Expected SeqStart event, found {:?}",
+                    self.deserializer.peek_event
+                ),
+            }));
+        }
+        let value = visitor.visit_seq(SeqCollection::new(self.deserializer))?;
+        match self.deserializer.next_el() {
+            Some(YamEvent::SeqEnd) => Ok(value),
+            _ => Err(DeYamlError(YamlError::Custom {
+                info: format!(
+                    "Expected SeqEnd event, found {:?}",
+                    self.deserializer.peek_event
+                ),
+            })),
+        }
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
+        bytes byte_buf option unit unit_struct newtype_struct  tuple
+        tuple_struct struct enum identifier ignored_any
+    }
+}
+
+struct MapCollection<'a, 'de: 'a, R>
+where
+    R: Source,
+{
+    iter: &'a mut YamlIterDeserializer<'de, R>,
+}
+
+impl<'a, 'de, R> MapCollection<'a, 'de, R>
+where
+    R: Source,
+{
+    fn new(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
+        MapCollection { iter }
+    }
+}
+
+impl<'de, 'a, R> MapAccess<'de> for MapCollection<'a, 'de, R>
+where
+    R: Source,
+{
+    type Error = DeYamlError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut *self.iter).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut *self.iter)
+    }
+}
+
+struct SeqCollection<'a, 'de: 'a, R>
+where
+    R: Source,
+{
+    iter: &'a mut YamlIterDeserializer<'de, R>,
+}
+
+impl<'a, 'de, R> SeqCollection<'a, 'de, R>
+where
+    R: Source,
+{
+    fn new(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
+        SeqCollection { iter }
+    }
+}
+
+impl<'de, 'a, R> SeqAccess<'de> for SeqCollection<'a, 'de, R>
+where
+    R: Source,
+{
+    type Error = DeYamlError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut *self.iter).map(Some)
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -8,7 +8,6 @@ use core::fmt::{Debug, Display, Formatter};
 
 use serde_core::de::{
     DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, StdError, VariantAccess,
-    Visitor,
 };
 use serde_core::{de, forward_to_deserialize_any};
 use yam_core::node::YamlScalar;
@@ -52,6 +51,16 @@ where
 
     fn skip(&mut self) {
         self.has_peeked = false;
+    }
+
+    fn peek_null(&mut self) -> bool {
+        if let Some(YamEvent::Scalar(scalar)) = self.skip_doc()
+            && (scalar.value == "null" || scalar.value == "~")
+        {
+            true
+        } else {
+            false
+        }
     }
 
     fn resolve_scalar<V: de::Visitor<'a>>(
@@ -219,9 +228,39 @@ where
         }
     }
 
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if self.peek_null() {
+            self.skip();
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if self.peek_null() {
+            self.skip();
+            visitor.visit_unit()
+        } else {
+            Err(DeYamlError::ExpectedNull)
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i128 u128 f32 f64 char str string
+        bytes byte_buf unit_struct newtype_struct tuple
+        tuple_struct struct ignored_any
+    }
+
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        V: de::Visitor<'de>,
     {
         if !matches!(self.skip_doc(), Some(YamEvent::SeqStart(_, _))) {
             return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
@@ -245,7 +284,7 @@ where
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>,
+        V: de::Visitor<'de>,
     {
         if !matches!(self.skip_doc(), Some(YamEvent::MapStart(_, _))) {
             return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
@@ -265,12 +304,6 @@ where
         }
         self.skip();
         Ok(val)
-    }
-
-    forward_to_deserialize_any! {
-        bool i128 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct tuple
-        tuple_struct struct ignored_any
     }
 
     fn deserialize_enum<V>(
@@ -341,6 +374,7 @@ pub enum DeYamlError {
     ParserError(YamlError),
     Custom(String),
     ExpectedStringInNewType,
+    ExpectedNull,
 }
 
 impl StdError for DeYamlError {}
@@ -351,6 +385,7 @@ impl Display for DeYamlError {
             DeYamlError::ParserError(err) => write!(f, "ParserError: {}", err)?,
             DeYamlError::Custom(msg) => write!(f, "Custom: {}", msg)?,
             DeYamlError::ExpectedStringInNewType => write!(f, "Expected String:")?,
+            DeYamlError::ExpectedNull => write!(f, "Expected Null")?,
         };
         Ok(())
     }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -1,41 +1,64 @@
 #![no_std]
 extern crate alloc;
 
-use alloc::string::{String, ToString};
-use core::fmt::{Display, Formatter};
-use serde_core::de;
-use serde_core::de::{MapAccess, SeqAccess};
-use yam_core::prelude::YamlError;
+use alloc::collections::BTreeMap;
+use alloc::format;
+use core::fmt::{Debug, Display, Formatter};
+use serde_core::de::StdError;
+use serde_core::{Deserializer, de};
+use yam_core::LazyExpander;
+use yam_core::parsing::ParserIter;
+use yam_core::parsing::parser_iter::YamEvent;
+use yam_core::prelude::{Source, YamlError};
+
+struct YamlIterDeserializer<'de, R>
+where
+    R: Source,
+{
+    yaml_iter: ParserIter<'de, R>,
+    alias: BTreeMap<usize, LazyExpander<'de>>,
+}
 
 #[derive(Debug)]
-pub enum YamSerdeError {
-    ParsingError(YamlError),
-    Custom(String),
-}
+struct DeYamlError(YamlError);
 
-impl YamSerdeError {
-    pub fn new_from_str(msg: &str) -> Self {
-        YamSerdeError::Custom(msg.to_string())
-    }
-}
+impl StdError for DeYamlError {}
 
-impl Display for YamSerdeError {
+impl Display for DeYamlError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        match self {
-            YamSerdeError::Custom(x) => write!(f, "Custom error: {x}")?,
-            YamSerdeError::ParsingError(yaml_error) => write!(f, "Parsing error: {yaml_error}")?,
-        }
-        Ok(())
+        f.debug_tuple("DeYamlError").field(&self.0).finish()
     }
 }
 
-impl de::StdError for YamSerdeError {}
-
-impl de::Error for YamSerdeError {
+impl de::Error for DeYamlError {
     fn custom<T>(msg: T) -> Self
     where
         T: Display,
     {
-        YamSerdeError::Custom(msg.to_string())
+        let info = format!("{}", msg);
+        DeYamlError(YamlError::Custom { info })
+    }
+}
+
+impl<'de, R, V> Deserializer<'de> for &'de mut YamlIterDeserializer<'de, R, V> {
+    type Error = DeYamlError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        for x in self.yaml_iter {
+            match x {
+                YamEvent::DocStart => {}
+                YamEvent::DocEnd => {}
+                YamEvent::StreamEnd => {}
+                YamEvent::Alias(_) => {}
+                YamEvent::Scalar(_) => {}
+                YamEvent::SeqStart(_, _) => {}
+                YamEvent::SeqEnd => {}
+                YamEvent::MapStart(_, _) => {}
+                YamEvent::MapEnd => {}
+            }
+        }
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -1,116 +1,23 @@
 #![no_std]
 extern crate alloc;
-use yam_core::prelude::YamlDocAccess;
 
 use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use core::fmt::{Display, Formatter};
-use core::marker::PhantomData;
-use serde_core::de::{DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde_core::de::{MapAccess, SeqAccess, Visitor};
 use serde_core::{de, forward_to_deserialize_any};
-use yam_core::node::YamlScalar;
-use yam_core::parsing::{Source, StrSource};
-use yam_core::prelude::{Yaml, YamlData, YamlEntry, YamlError, YamlLoader};
-
-///
-/// Attempts to deserialize a value of type `T` from a given YAML string slice.
-///
-/// This function takes a string slice as input and attempts to deserialize it
-/// into the specified type `T` using the `Deserialize` trait from the `serde`
-/// library. The deserialization process may fail if the input string is not
-/// valid YAML or if it does not conform to the structure of type `T`.
-///
-/// # Type Parameters
-///
-/// * `T`: The type into which the given YAML string will be deserialized.
-///   `T` must implement the `Deserialize<'a>` trait.
-///
-/// # Parameters
-///
-/// * `input`: A string slice containing the YAML-encoded data to deserialize.
-///
-/// # Returns
-///
-/// * `Ok(T)`: Returns an object of type `T` if the deserialization is successful.
-/// * `Err(YamSerdeError)`: Returns a `YamSerdeError` if the deserialization fails.
-///
-/// # Errors
-///
-/// This function will return a `YamSerdeError` if:
-/// * The input string is not valid YAML.
-/// * The structure or data in the YAML string does not match the structure of type `T`.
-///
-/// # Example
-///
-/// ```rust
-/// use yam_serde::{from_str, YamSerdeError};
-/// use serde::Deserialize;
-///
-/// #[derive(Deserialize, Debug)]
-/// struct Config {
-///     host: String,
-///     port: u16,
-/// }
-///
-/// fn main() -> Result<(), YamSerdeError> {
-///     let yaml_data = r#"
-///         host: localhost
-///         port: 8080
-///     "#;
-///
-///     let config: Config = from_str(yaml_data)?;
-///     println!("Parsed config: {:?}", config);
-///     Ok(())
-/// }
-/// ```
-///
-/// In this example, the `from_str` function is used to parse a YAML string into
-/// a `Config` struct. If the parsing is successful, the function returns the
-/// struct; otherwise, it returns an error.
-///
-/// # Note
-///
-/// This function uses `Deserializer` and `StrSource` internally for processing
-/// the YAML input.
-///
-pub fn from_str<'a, T>(input: &'a str) -> Result<T, YamSerdeError>
-where
-    T: de::Deserialize<'a>,
-{
-    let de = Deserializer::new(StrSource::new(input));
-    let value = de::Deserialize::deserialize(de)?;
-
-    Ok(value)
-}
-
-struct Deserializer<'a, R: Source> {
-    input: R,
-    phantom_data: PhantomData<&'a ()>,
-}
-
-#[allow(dead_code)]
-impl<'a> Deserializer<'a, StrSource<'a>> {
-    pub fn from_str<S: AsRef<str>>(input: &'a S) -> Self {
-        Self::new(StrSource::new(input.as_ref()))
-    }
-}
-
-impl<R> Deserializer<'_, R>
-where
-    R: Source,
-{
-    fn new(input: R) -> Self {
-        Self {
-            input,
-            phantom_data: PhantomData,
-        }
-    }
-}
+use yam_core::parsing::{Event, Parser, ScalarValue, Source, StrSource};
+use yam_core::prelude::YamlError;
 
 #[derive(Debug)]
 pub enum YamSerdeError {
     ParsingError(YamlError),
     Custom(String),
+}
+
+impl YamSerdeError {
+    pub fn from_str(msg: &str) -> Self {
+        YamSerdeError::Custom(msg.to_string())
+    }
 }
 
 impl Display for YamSerdeError {
@@ -134,7 +41,112 @@ impl de::Error for YamSerdeError {
     }
 }
 
-impl<'de, R> de::Deserializer<'de> for Deserializer<'de, R>
+struct Deserializer<'de, R: Source> {
+    parser: Parser<'de, R>,
+    state: State,
+}
+
+#[derive(Default, PartialEq, Eq, Clone, Copy)]
+enum State {
+    #[default]
+    StreamStart,
+    Document,
+    Sequence,
+}
+
+#[allow(dead_code)]
+impl<'a> Deserializer<'a, StrSource<'a>> {
+    pub fn from_str<S: AsRef<str>>(input: &'a S) -> Self {
+        Self::new(StrSource::new(input.as_ref()))
+    }
+}
+
+impl<'de, R> Deserializer<'de, R>
+where
+    R: Source,
+{
+    fn new(input: R) -> Self {
+        Self {
+            parser: Parser::new(input),
+            state: State::StreamStart,
+        }
+    }
+
+    fn next_doc_start(&mut self) -> Result<(), YamSerdeError> {
+        if let Ok((ev1, _)) = self.parser.next_event_impl()
+            && ev1 == Event::StreamStart
+        {
+            if let Ok((ev2, _)) = self.parser.next_event_impl()
+                && matches!(ev2, Event::DocumentStart(_))
+            {
+                return Ok(());
+            }
+        }
+        Err(YamSerdeError::Custom("Invalid document start".to_string()))
+    }
+
+    fn next_doc_end(&mut self) -> Result<(), YamSerdeError> {
+        if let Ok((ev1, _)) = self.parser.next_event_impl()
+            && ev1 == Event::DocumentEnd
+        {
+            return Ok(());
+        }
+        Err(YamSerdeError::from_str("Invalid document end"))
+    }
+
+    fn match_initial<V>(&mut self, visitor: V) -> Result<V::Value, YamSerdeError>
+    where
+        V: Visitor<'de>,
+    {
+        self.next_doc_start()?;
+        self.state = State::Document;
+        let x = self.match_document(visitor)?;
+        self.next_doc_end()?;
+        Ok(x)
+    }
+
+    fn match_document<V>(&mut self, visitor: V) -> Result<V::Value, YamSerdeError>
+    where
+        V: Visitor<'de>,
+    {
+        let x = self
+            .parser
+            .next_event_impl()
+            .map_err(|x| YamSerdeError::ParsingError(x))?;
+        match x.0 {
+            Event::Nothing => visitor.visit_none(),
+            Event::StreamStart | Event::DocumentStart(_) => {
+                return Err(YamSerdeError::from_str("Unexpected start of document"));
+            }
+            Event::StreamEnd | Event::DocumentEnd => {
+                return Err(YamSerdeError::from_str("Unexpected end of document"));
+            }
+            Event::Alias(id) => self.resolve_alias(id, visitor),
+            Event::Comment(_) => self.match_document(visitor),
+            Event::Scalar(x) => self.resolve_scalar(x, visitor),
+            Event::SequenceStart(_, _) => {}
+            Event::SequenceEnd => {}
+            Event::MappingStart(_, _) => {}
+            Event::MappingEnd => {}
+        }
+    }
+
+    fn resolve_alias<V>(&self, id: usize, vistor: V) -> Result<V::Value, YamSerdeError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(YamSerdeError::from_str("Alias resolution not implemented"))
+    }
+
+    fn resolve_scalar<V>(&self, id: ScalarValue<'de>, vistor: V) -> Result<V::Value, YamSerdeError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(YamSerdeError::from_str("Scalar resolution not implemented"))
+    }
+}
+
+impl<'de, R> de::Deserializer<'de> for &mut Deserializer<'de, R>
 where
     R: Source,
 {
@@ -144,123 +156,10 @@ where
     where
         V: Visitor<'de>,
     {
-        let doc = match YamlLoader::<Yaml<'de>>::load_single_source(self.input) {
-            Ok(x) => x,
-            Err(e) => return Err(YamSerdeError::ParsingError(e)),
-        };
-        YamDocDeserializer { doc }.deserialize_any(visitor)
-    }
-
-    forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
-    }
-}
-
-struct YamSequenceDeserializer<'de> {
-    sequence: Vec<Yaml<'de>>,
-    idx: usize,
-}
-
-impl<'de> YamSequenceDeserializer<'de> {
-    fn new(sequence: Vec<Yaml<'de>>) -> Self {
-        Self { sequence, idx: 0 }
-    }
-}
-
-impl<'de> SeqAccess<'de> for YamSequenceDeserializer<'de> {
-    type Error = YamSerdeError;
-
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        let element = self.sequence.get_mut(self.idx);
-        match element {
-            Some(d) => {
-                self.idx += 1;
-                seed.deserialize(YamDocDeserializer::take_from_ref(d))
-                    .map(Some)
-            }
-            None => Ok(None),
-        }
-    }
-}
-
-struct YamMapDeserializer<'de> {
-    mapping: Vec<YamlEntry<'de, Yaml<'de>>>,
-    idx: usize,
-}
-
-impl<'de> YamMapDeserializer<'de> {
-    fn new(mapping: Vec<YamlEntry<'de, Yaml<'de>>>) -> Self {
-        Self { mapping, idx: 0 }
-    }
-}
-
-impl<'de> MapAccess<'de> for YamMapDeserializer<'de> {
-    type Error = YamSerdeError;
-
-    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-    where
-        K: DeserializeSeed<'de>,
-    {
-        let entry = self.mapping.get_mut(self.idx);
-        match entry {
-            Some(entry) => seed
-                .deserialize(YamDocDeserializer::take_from_ref(&mut entry.key))
-                .map(Some),
-            None => Ok(None),
-        }
-    }
-
-    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-    where
-        V: DeserializeSeed<'de>,
-    {
-        let entry = self.mapping.get_mut(self.idx);
-        match entry {
-            Some(entry) => {
-                // TODO Do we get key or map first??
-                self.idx += 1;
-                seed.deserialize(YamDocDeserializer::take_from_ref(&mut entry.value))
-            }
-            // TODO is this safe?
-            None => unreachable!("Should not be possible to get here because we had a key"),
-        }
-    }
-}
-
-struct YamDocDeserializer<'de> {
-    doc: Yaml<'de>,
-}
-
-impl<'de> YamDocDeserializer<'de> {
-    fn take_from_ref<'a>(new: &'a mut Yaml<'de>) -> YamDocDeserializer<'de> {
-        Self { doc: new.take() }
-    }
-}
-
-impl<'de> de::Deserializer<'de> for YamDocDeserializer<'de> {
-    type Error = YamSerdeError;
-
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match self.doc.0 {
-            YamlData::BadValue => Err(YamSerdeError::Custom(
-                "Bad value during parsing found!".to_string(),
-            )),
-            YamlData::Scalar(YamlScalar::Null(_)) => visitor.visit_none(),
-            YamlData::Scalar(YamlScalar::Bool(b)) => visitor.visit_bool(b),
-            YamlData::Scalar(YamlScalar::String(s)) => visitor.visit_str(&s),
-            YamlData::Scalar(YamlScalar::FloatingPoint(fp)) => visitor.visit_f64(fp),
-            YamlData::Scalar(YamlScalar::Integer(i)) => visitor.visit_i64(i),
-            YamlData::Sequence(seq) => visitor.visit_seq(YamSequenceDeserializer::new(seq)),
-            YamlData::Mapping(map) => visitor.visit_map(YamMapDeserializer::new(map)),
-            YamlData::Alias(_) | YamlData::Tagged(..) => unimplemented!("TODO"),
+        match self.state {
+            State::StreamStart => self.match_initial(visitor),
+            State::Document => self.match_document(visitor),
+            _ => Err(YamSerdeError::Custom("Unexpected state".to_string())),
         }
     }
 

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -179,30 +179,6 @@ where
         }
     }
 
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: de::Visitor<'de>,
-    {
-        if !matches!(self.deserializer.peek_event, YamEvent::MapStart(_, _)) {
-            return Err(DeYamlError(YamlError::Custom {
-                info: format!(
-                    "Expected MapStart event, found {:?}",
-                    self.deserializer.peek_event
-                ),
-            }));
-        }
-        let value = visitor.visit_map(MapCollection::new(self.deserializer))?;
-        match self.deserializer.next_el() {
-            Some(YamEvent::MapEnd) => Ok(value),
-            _ => Err(DeYamlError(YamlError::Custom {
-                info: format!(
-                    "Expected MapEnd event, found {:?}",
-                    self.deserializer.peek_event
-                ),
-            })),
-        }
-    }
-
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
@@ -221,6 +197,30 @@ where
             _ => Err(DeYamlError(YamlError::Custom {
                 info: format!(
                     "Expected SeqEnd event, found {:?}",
+                    self.deserializer.peek_event
+                ),
+            })),
+        }
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if !matches!(self.deserializer.peek_event, YamEvent::MapStart(_, _)) {
+            return Err(DeYamlError(YamlError::Custom {
+                info: format!(
+                    "Expected MapStart event, found {:?}",
+                    self.deserializer.peek_event
+                ),
+            }));
+        }
+        let value = visitor.visit_map(MapCollection::new(self.deserializer))?;
+        match self.deserializer.next_el() {
+            Some(YamEvent::MapEnd) => Ok(value),
+            _ => Err(DeYamlError(YamlError::Custom {
+                info: format!(
+                    "Expected MapEnd event, found {:?}",
                     self.deserializer.peek_event
                 ),
             })),
@@ -260,6 +260,7 @@ where
     where
         K: DeserializeSeed<'de>,
     {
+        // TODO check for next event
         seed.deserialize(&mut *self.iter).map(Some)
     }
 
@@ -297,6 +298,7 @@ where
     where
         T: DeserializeSeed<'de>,
     {
+        // TODO check for next event
         seed.deserialize(&mut *self.iter).map(Some)
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -3,11 +3,11 @@
 extern crate alloc;
 
 use alloc::format;
-
+use alloc::string::ToString;
 use core::fmt::{Debug, Display, Formatter};
 use serde_core::de::{DeserializeSeed, MapAccess, SeqAccess, StdError};
 use serde_core::{Deserializer, de, forward_to_deserialize_any};
-use yam_core::node::YamlScalar;
+use yam_core::node::{YamlScalar, parse_i64_from_cow};
 use yam_core::parsing::parser_iter::YamEvent;
 use yam_core::parsing::{ParserIter, ScalarValue, StrSource};
 use yam_core::prelude::{Source, YamlError};
@@ -84,8 +84,46 @@ where
         }
     }
 
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Some(YamEvent::Scalar(scalar)) = self.next_el() {
+            self.is_peeked = false;
+            match parse_i64_from_cow(&scalar.value) {
+                Ok(int) => visitor.visit_i32(int as i32),
+                Err(_) => Err(DeYamlError(YamlError::Custom {
+                    info: "Failed to parse i32 from scalar value".to_string(),
+                })),
+            }
+        } else {
+            Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for i32 deserialization".to_string(),
+            }))
+        }
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if let Some(YamEvent::Scalar(scalar)) = self.next_el() {
+            self.is_peeked = false;
+            match parse_i64_from_cow(&scalar.value) {
+                Ok(int) => visitor.visit_i64(int),
+                Err(_) => Err(DeYamlError(YamlError::Custom {
+                    info: "Failed to parse i32 from scalar value".to_string(),
+                })),
+            }
+        } else {
+            Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for i32 deserialization".to_string(),
+            }))
+        }
+    }
+
     forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bool i8 i16 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -18,6 +18,7 @@ where
 {
     yaml_iter: ParserIter<'de, R>,
     peek_event: YamEvent<'de>,
+    is_peeked: bool,
 }
 
 impl<'a> YamlIterDeserializer<'a, StrSource<'a>> {
@@ -25,6 +26,7 @@ impl<'a> YamlIterDeserializer<'a, StrSource<'a>> {
         YamlIterDeserializer {
             yaml_iter: ParserIter::new(StrSource::new(source)),
             peek_event: YamEvent::DocStart,
+            is_peeked: false,
         }
     }
 }
@@ -34,12 +36,29 @@ where
     R: Source,
 {
     fn next_el(&mut self) -> Option<YamEvent<'a>> {
-        match self.yaml_iter.next() {
-            Some(x) => {
-                self.peek_event = x.clone();
-                Some(x)
-            }
-            None => None,
+        if self.is_peeked {
+            self.is_peeked = false;
+            return Some(self.peek_event.clone());
+        }
+
+        self.is_peeked = true;
+        self.peek_event = self.yaml_iter.next()?;
+        Some(self.peek_event.clone())
+    }
+
+    fn resolve_scalar<V: de::Visitor<'a>>(
+        &mut self,
+        scalar_value: ScalarValue,
+        visitor: V,
+    ) -> Result<V::Value, DeYamlError> {
+        let scalar = YamlScalar::parse_from_scalar(scalar_value);
+        match scalar {
+            Some(YamlScalar::Integer(x)) => visitor.visit_i64(x),
+            Some(YamlScalar::FloatingPoint(x)) => visitor.visit_f64(x),
+            Some(YamlScalar::Bool(x)) => visitor.visit_bool(x),
+            Some(YamlScalar::String(x)) => visitor.visit_str(&x),
+            Some(YamlScalar::Null(_)) => visitor.visit_unit(),
+            None => Err(DeYamlError(YamlError::new_custom("Failed to parse scalar"))),
         }
     }
 }
@@ -54,10 +73,13 @@ where
     where
         V: de::Visitor<'de>,
     {
-        match self.yaml_iter.next() {
-            Some(YamEvent::DocStart) => DocSerializer::new(self).deserialize_any(visitor),
+        match self.next_el() {
+            Some(YamEvent::DocStart) => {
+                self.is_peeked = false;
+                DocSerializer::new(self).deserialize_any(visitor)
+            }
             e => Err(DeYamlError(YamlError::Custom {
-                info: format!("Unexpected event (can only process DocStart: {:?}", e),
+                info: format!("Unexpected event (can only process DocStart): {:?}", e),
             })),
         }
     }
@@ -122,15 +144,7 @@ where
         scalar_value: ScalarValue,
         visitor: V,
     ) -> Result<V::Value, DeYamlError> {
-        let scalar = YamlScalar::parse_from_scalar(scalar_value);
-        match scalar {
-            Some(YamlScalar::Integer(x)) => visitor.visit_i64(x),
-            Some(YamlScalar::FloatingPoint(x)) => visitor.visit_f64(x),
-            Some(YamlScalar::Bool(x)) => visitor.visit_bool(x),
-            Some(YamlScalar::String(x)) => visitor.visit_str(&x),
-            Some(YamlScalar::Null(_)) => visitor.visit_unit(),
-            None => Err(DeYamlError(YamlError::new_custom("Failed to parse scalar"))),
-        }
+        self.deserializer.resolve_scalar(scalar_value, visitor)
     }
 }
 
@@ -152,7 +166,7 @@ where
             YamEvent::MapStart(_, _) => self.deserialize_map(visitor),
             YamEvent::SeqStart(_, _) => self.deserialize_seq(visitor),
             e => Err(DeYamlError(YamlError::Custom {
-                info: format!("Unexpected event: {:?}", e),
+                info: format!("Unexpected event in serialize: {:?}", e),
             })),
         }
     }
@@ -192,8 +206,8 @@ where
             }));
         }
         let value = visitor.visit_seq(SeqCollection::new(self.deserializer))?;
-        match self.deserializer.next_el() {
-            Some(YamEvent::SeqEnd) => Ok(value),
+        match self.deserializer.peek_event {
+            YamEvent::SeqEnd => Ok(value),
             _ => Err(DeYamlError(YamlError::Custom {
                 info: format!(
                     "Expected SeqEnd event, found {:?}",
@@ -216,8 +230,8 @@ where
             }));
         }
         let value = visitor.visit_map(MapCollection::new(self.deserializer))?;
-        match self.deserializer.next_el() {
-            Some(YamEvent::MapEnd) => Ok(value),
+        match self.deserializer.peek_event {
+            YamEvent::MapEnd => Ok(value),
             _ => Err(DeYamlError(YamlError::Custom {
                 info: format!(
                     "Expected MapEnd event, found {:?}",
@@ -260,8 +274,15 @@ where
     where
         K: DeserializeSeed<'de>,
     {
-        // TODO check for next event
-        seed.deserialize(&mut *self.iter).map(Some)
+        match self.iter.next_el() {
+            Some(YamEvent::MapEnd) => Ok(None),
+            Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
+                Err(DeYamlError(YamlError::Custom {
+                    info: format!("Expected map key, found {:?}", self.iter.peek_event),
+                }))
+            }
+            Some(_) => seed.deserialize(&mut *self.iter).map(Some),
+        }
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
@@ -298,7 +319,14 @@ where
     where
         T: DeserializeSeed<'de>,
     {
-        // TODO check for next event
-        seed.deserialize(&mut *self.iter).map(Some)
+        match self.iter.next_el() {
+            Some(YamEvent::SeqEnd) => Ok(None),
+            Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
+                Err(DeYamlError(YamlError::Custom {
+                    info: format!("Expected seq, found {:?}", self.iter.peek_event),
+                }))
+            }
+            Some(_) => seed.deserialize(&mut *self.iter).map(Some),
+        }
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -6,7 +6,10 @@ use alloc::format;
 use alloc::string::ToString;
 use core::fmt::{Debug, Display, Formatter};
 use core::i64;
-use serde_core::de::{DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, StdError};
+use serde_core::de::{
+    DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, StdError, VariantAccess,
+    Visitor,
+};
 use serde_core::{Deserializer, de, forward_to_deserialize_any};
 use yam_core::node::YamlScalar;
 use yam_core::parsing::parser_iter::YamEvent;
@@ -223,15 +226,28 @@ where
     where
         V: de::Visitor<'de>,
     {
-        Err(DeYamlError(YamlError::Custom {
-            info: "Enum deserialization not supported".to_string(),
-        }))
+        match self.skip_doc() {
+            Some(YamEvent::Scalar(ScalarValue { value, .. })) => {
+                self.skip();
+                visitor.visit_enum(value.into_deserializer())
+            }
+            _ => Err(DeYamlError(YamlError::Custom {
+                info: "Expected scalar event for enum deserialization".to_string(),
+            })),
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
     }
 
     forward_to_deserialize_any! {
         bool i128 u128 f32 f64 char str string
         bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct identifier ignored_any
+        tuple_struct map struct ignored_any
     }
 }
 
@@ -332,6 +348,7 @@ where
     R: Source,
 {
     iter: &'a mut YamlIterDeserializer<'de, R>,
+    first: bool,
 }
 
 impl<'a, 'de, R> SeqCollection<'a, 'de, R>
@@ -339,7 +356,7 @@ where
     R: Source,
 {
     fn new(iter: &'a mut YamlIterDeserializer<'de, R>) -> Self {
-        SeqCollection { iter }
+        SeqCollection { iter, first: true }
     }
 }
 
@@ -353,8 +370,21 @@ where
     where
         T: DeserializeSeed<'de>,
     {
+        if self.first {
+            self.first = false;
+            if !matches!(self.iter.last_event, YamEvent::SeqStart(_, _)) {
+                return Err(DeYamlError(YamlError::Custom {
+                    info: format!("Expected SeqStart, found {:?}", self.iter.last_event),
+                }));
+            }
+            self.iter.skip();
+        }
+
         match self.iter.next_el() {
-            Some(YamEvent::SeqEnd) => Ok(None),
+            Some(YamEvent::SeqEnd) => {
+                self.iter.skip();
+                Ok(None)
+            }
             Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
                 Err(DeYamlError(YamlError::Custom {
                     info: format!("Expected seq, found {:?}", self.iter.last_event),
@@ -379,5 +409,58 @@ where
 {
     fn new(de: &'a mut YamlIterDeserializer<'de, R>) -> Self {
         Enum { de }
+    }
+}
+
+impl<'a, 'de, R> EnumAccess<'de> for Enum<'a, 'de, R>
+where
+    'de: 'a,
+    R: Source,
+{
+    type Error = DeYamlError;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        todo!()
+    }
+}
+
+impl<'a, 'de, R> VariantAccess<'de> for Enum<'a, 'de, R>
+where
+    'de: 'a,
+    R: Source,
+{
+    type Error = DeYamlError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        todo!()
+    }
+
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        todo!()
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        todo!()
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -3,9 +3,8 @@ extern crate alloc;
 
 use alloc::string::{String, ToString};
 use core::fmt::{Display, Formatter};
-use serde_core::de::{MapAccess, SeqAccess, Visitor};
-use serde_core::{de, forward_to_deserialize_any};
-use yam_core::parsing::{Event, Parser, ScalarValue, Source, StrSource};
+use serde_core::de;
+use serde_core::de::{MapAccess, SeqAccess};
 use yam_core::prelude::YamlError;
 
 #[derive(Debug)]
@@ -15,7 +14,7 @@ pub enum YamSerdeError {
 }
 
 impl YamSerdeError {
-    pub fn from_str(msg: &str) -> Self {
+    pub fn new_from_str(msg: &str) -> Self {
         YamSerdeError::Custom(msg.to_string())
     }
 }
@@ -38,134 +37,5 @@ impl de::Error for YamSerdeError {
         T: Display,
     {
         YamSerdeError::Custom(msg.to_string())
-    }
-}
-
-struct Deserializer<'de, R: Source> {
-    parser: Parser<'de, R>,
-    state: State,
-}
-
-#[derive(Default, PartialEq, Eq, Clone, Copy)]
-enum State {
-    #[default]
-    StreamStart,
-    Document,
-    Sequence,
-}
-
-#[allow(dead_code)]
-impl<'a> Deserializer<'a, StrSource<'a>> {
-    pub fn from_str<S: AsRef<str>>(input: &'a S) -> Self {
-        Self::new(StrSource::new(input.as_ref()))
-    }
-}
-
-impl<'de, R> Deserializer<'de, R>
-where
-    R: Source,
-{
-    fn new(input: R) -> Self {
-        Self {
-            parser: Parser::new(input),
-            state: State::StreamStart,
-        }
-    }
-
-    fn next_doc_start(&mut self) -> Result<(), YamSerdeError> {
-        if let Ok((ev1, _)) = self.parser.next_event_impl()
-            && ev1 == Event::StreamStart
-        {
-            if let Ok((ev2, _)) = self.parser.next_event_impl()
-                && matches!(ev2, Event::DocumentStart(_))
-            {
-                return Ok(());
-            }
-        }
-        Err(YamSerdeError::Custom("Invalid document start".to_string()))
-    }
-
-    fn next_doc_end(&mut self) -> Result<(), YamSerdeError> {
-        if let Ok((ev1, _)) = self.parser.next_event_impl()
-            && ev1 == Event::DocumentEnd
-        {
-            return Ok(());
-        }
-        Err(YamSerdeError::from_str("Invalid document end"))
-    }
-
-    fn match_initial<V>(&mut self, visitor: V) -> Result<V::Value, YamSerdeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.next_doc_start()?;
-        self.state = State::Document;
-        let x = self.match_document(visitor)?;
-        self.next_doc_end()?;
-        Ok(x)
-    }
-
-    fn match_document<V>(&mut self, visitor: V) -> Result<V::Value, YamSerdeError>
-    where
-        V: Visitor<'de>,
-    {
-        let x = self
-            .parser
-            .next_event_impl()
-            .map_err(|x| YamSerdeError::ParsingError(x))?;
-        match x.0 {
-            Event::Nothing => visitor.visit_none(),
-            Event::StreamStart | Event::DocumentStart(_) => {
-                return Err(YamSerdeError::from_str("Unexpected start of document"));
-            }
-            Event::StreamEnd | Event::DocumentEnd => {
-                return Err(YamSerdeError::from_str("Unexpected end of document"));
-            }
-            Event::Alias(id) => self.resolve_alias(id, visitor),
-            Event::Comment(_) => self.match_document(visitor),
-            Event::Scalar(x) => self.resolve_scalar(x, visitor),
-            Event::SequenceStart(_, _) => {}
-            Event::SequenceEnd => {}
-            Event::MappingStart(_, _) => {}
-            Event::MappingEnd => {}
-        }
-    }
-
-    fn resolve_alias<V>(&self, id: usize, vistor: V) -> Result<V::Value, YamSerdeError>
-    where
-        V: Visitor<'de>,
-    {
-        Err(YamSerdeError::from_str("Alias resolution not implemented"))
-    }
-
-    fn resolve_scalar<V>(&self, id: ScalarValue<'de>, vistor: V) -> Result<V::Value, YamSerdeError>
-    where
-        V: Visitor<'de>,
-    {
-        Err(YamSerdeError::from_str("Scalar resolution not implemented"))
-    }
-}
-
-impl<'de, R> de::Deserializer<'de> for &mut Deserializer<'de, R>
-where
-    R: Source,
-{
-    type Error = YamSerdeError;
-
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match self.state {
-            State::StreamStart => self.match_initial(visitor),
-            State::Document => self.match_document(visitor),
-            _ => Err(YamSerdeError::Custom("Unexpected state".to_string())),
-        }
-    }
-
-    forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
     }
 }

--- a/yam-serde/src/lib.rs
+++ b/yam-serde/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::format;
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 use core::fmt::{Debug, Display, Formatter};
 use core::i64;
 use serde_core::de::{
@@ -66,7 +66,7 @@ where
             Some(YamlScalar::Bool(x)) => visitor.visit_bool(x),
             Some(YamlScalar::String(x)) => visitor.visit_str(&x),
             Some(YamlScalar::Null(_)) => visitor.visit_unit(),
-            None => Err(DeYamlError(YamlError::new_custom("Failed to parse scalar"))),
+            None => Err(DeYamlError::Custom("Failed to parse scalar".to_string())),
         }
     }
 }
@@ -75,9 +75,10 @@ macro_rules! parse_from_cow {
     ($e:expr, $v:expr, $method:ident, $t:ty) => {
         match $e.parse::<$t>() {
             Ok(i) => $v.$method(i),
-            Err(_) => Err(DeYamlError(YamlError::Custom {
-                info: format!("Failed to parse {:?} from scalar value", stringify!($t)),
-            })),
+            Err(_) => Err(DeYamlError::Custom(format!(
+                "Failed to parse {:?} from scalar value",
+                stringify!($t)
+            ))),
         }
     };
 }
@@ -99,9 +100,10 @@ where
                 self.skip();
                 self.resolve_scalar(scalr, visitor)
             }
-            e => Err(DeYamlError(YamlError::Custom {
-                info: format!("Unexpected event (can only process DocStart): {:?}", e),
-            })),
+            e => Err(DeYamlError::Custom(format!(
+                "Unexpected event (can only process DocStart): {:?}",
+                e
+            ))),
         }
     }
 
@@ -113,9 +115,9 @@ where
             self.has_peeked = false;
             parse_from_cow!(&scalar.value, visitor, visit_i8, i8)
         } else {
-            Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for i32 deserialization".to_string(),
-            }))
+            Err(DeYamlError::Custom(
+                "Expected scalar event for i32 deserialization".to_string(),
+            ))
         }
     }
 
@@ -127,9 +129,9 @@ where
             self.has_peeked = false;
             parse_from_cow!(&scalar.value, visitor, visit_i16, i16)
         } else {
-            Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for i16 deserialization".to_string(),
-            }))
+            Err(DeYamlError::Custom(
+                "Expected scalar event for i16 deserialization".to_string(),
+            ))
         }
     }
 
@@ -141,9 +143,9 @@ where
             self.skip();
             parse_from_cow!(&scalar.value, visitor, visit_i32, i32)
         } else {
-            Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for i32 deserialization".to_string(),
-            }))
+            Err(DeYamlError::Custom(
+                "Expected scalar event for i32 deserialization".to_string(),
+            ))
         }
     }
 
@@ -155,9 +157,9 @@ where
             self.skip();
             parse_from_cow!(&scalar.value, visitor, visit_i64, i64)
         } else {
-            Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for i64 deserialization".to_string(),
-            }))
+            Err(DeYamlError::Custom(
+                "Expected scalar event for i64 deserialization".to_string(),
+            ))
         }
     }
 
@@ -169,9 +171,9 @@ where
             self.has_peeked = false;
             parse_from_cow!(&scalar.value, visitor, visit_u8, u8)
         } else {
-            Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for u8 deserialization".to_string(),
-            }))
+            Err(DeYamlError::Custom(
+                "Expected scalar event for i8 deserialization".to_string(),
+            ))
         }
     }
 
@@ -183,9 +185,9 @@ where
             self.has_peeked = false;
             parse_from_cow!(&scalar.value, visitor, visit_u16, u16)
         } else {
-            Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for u16 deserialization".to_string(),
-            }))
+            Err(DeYamlError::Custom(
+                "Expected scalar event for u16 deserialization".to_string(),
+            ))
         }
     }
 
@@ -197,9 +199,9 @@ where
             self.skip();
             parse_from_cow!(&scalar.value, visitor, visit_u32, u32)
         } else {
-            Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for u32 deserialization".to_string(),
-            }))
+            Err(DeYamlError::Custom(
+                "Expected scalar event for u32 deserialization".to_string(),
+            ))
         }
     }
 
@@ -211,9 +213,9 @@ where
             self.skip();
             parse_from_cow!(&scalar.value, visitor, visit_u64, u64)
         } else {
-            Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for u64 deserialization".to_string(),
-            }))
+            Err(DeYamlError::Custom(
+                "Expected scalar event for u64 deserialization".to_string(),
+            ))
         }
     }
 
@@ -231,9 +233,9 @@ where
                 self.skip();
                 visitor.visit_enum(value.into_deserializer())
             }
-            _ => Err(DeYamlError(YamlError::Custom {
-                info: "Expected scalar event for enum deserialization".to_string(),
-            })),
+            _ => Err(DeYamlError::Custom(
+                "Expected scalar event for enum deserialization".to_string(),
+            )),
         }
     }
 
@@ -277,13 +279,20 @@ where
 }
 
 #[derive(Debug)]
-pub struct DeYamlError(YamlError);
+pub enum DeYamlError {
+    ParserError(YamlError),
+    Custom(String),
+}
 
 impl StdError for DeYamlError {}
 
 impl Display for DeYamlError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("DeYamlError").field(&self.0).finish()
+        match self {
+            DeYamlError::ParserError(err) => write!(f, "ParserError: {}", err)?,
+            DeYamlError::Custom(msg) => write!(f, "Custom: {}", msg)?,
+        };
+        Ok(())
     }
 }
 
@@ -293,7 +302,7 @@ impl de::Error for DeYamlError {
         T: Display,
     {
         let info = format!("{}", msg);
-        DeYamlError(YamlError::Custom { info })
+        DeYamlError::Custom(info)
     }
 }
 
@@ -326,8 +335,9 @@ where
         match self.iter.next_el() {
             Some(YamEvent::MapEnd) => Ok(None),
             Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
-                Err(DeYamlError(YamlError::Custom {
-                    info: format!("Expected map key, found {:?}", self.iter.last_event),
+                Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                    expected: "MapEnd",
+                    found: self.iter.last_event.as_simple_str(),
                 }))
             }
             Some(_) => seed.deserialize(&mut *self.iter).map(Some),
@@ -338,6 +348,7 @@ where
     where
         V: DeserializeSeed<'de>,
     {
+        // TODO
         let val = seed.deserialize(&mut *self.iter)?;
         Ok(val)
     }
@@ -373,8 +384,9 @@ where
         if self.first {
             self.first = false;
             if !matches!(self.iter.last_event, YamEvent::SeqStart(_, _)) {
-                return Err(DeYamlError(YamlError::Custom {
-                    info: format!("Expected SeqStart, found {:?}", self.iter.last_event),
+                return Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                    expected: "SeqStart",
+                    found: self.iter.last_event.as_simple_str(),
                 }));
             }
             self.iter.skip();
@@ -386,8 +398,9 @@ where
                 Ok(None)
             }
             Some(YamEvent::DocEnd | YamEvent::StreamEnd) | None => {
-                Err(DeYamlError(YamlError::Custom {
-                    info: format!("Expected seq, found {:?}", self.iter.last_event),
+                Err(DeYamlError::ParserError(YamlError::UnExpectedEvent {
+                    expected: "SeqEnd",
+                    found: self.iter.last_event.as_simple_str(),
                 }))
             }
             Some(_) => seed.deserialize(&mut *self.iter).map(Some),
@@ -424,7 +437,8 @@ where
     where
         V: DeserializeSeed<'de>,
     {
-        todo!()
+        let val = seed.deserialize(&mut *self.de)?;
+        Ok((val, self))
     }
 }
 

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -128,6 +128,17 @@ fn test_deserialize_list_f64() {
 }
 
 #[test]
+fn test_deserialize_option() {
+    let input = r#"3"#;
+    let deserialized: Option<i32> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, Some(3));
+
+    let input = r#"null"#;
+    let deserialized: Option<i32> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, None);
+}
+
+#[test]
 fn test_enum() {
     #[derive(Deserialize, PartialEq, Debug)]
     enum E {

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -123,18 +123,18 @@ fn test_enum() {
         Struct { a: u32 },
     }
 
-    let j = r#""Unit""#;
-    let expected = E::Unit;
-    assert_eq!(expected, yam_serde::from_str(j).unwrap());
+    // let j = r#""Unit""#;
+    // let expected = E::Unit;
+    // assert_eq!(expected, yam_serde::from_str(j).unwrap());
     //
-    // let j = r#"{"Newtype":1}"#;
+    // let j = r#"{"Newtype": 1}"#;
     // let expected = E::Newtype(1);
     // assert_eq!(expected, yam_serde::from_str(j).unwrap());
-    //
-    // let j = r#"{"Tuple":[1,2]}"#;
-    // let expected = E::Tuple(1, 2);
-    // assert_eq!(expected, yam_serde::from_str(j).unwrap());
-    //
+
+    let j = r#"{"Tuple":[1,2]}"#;
+    let expected = E::Tuple(1, 2);
+    assert_eq!(expected, yam_serde::from_str(j).unwrap());
+
     // let j = r#"{"Struct":{"a":1}}"#;
     // let expected = E::Struct { a: 1 };
     // assert_eq!(expected, yam_serde::from_str(j).unwrap());

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -4,15 +4,15 @@ use serde::Deserialize;
 #[derive(Deserialize, Debug)]
 pub struct Ex {
     a: String,
-    b: String,
+    b: Vec<f32>,
 }
 
 #[test]
 fn test_example() {
-    let ex = r#"{ a: "x",  b: "y" }"#;
+    let ex = r#"{ a: "x",  b: [2.0, 3.1, -1.2] }"#;
     let deserialized: Ex = yam_serde::from_str(ex).unwrap();
     assert_eq!(deserialized.a, "x");
-    assert_eq!(deserialized.b, "y");
+    assert_eq!(deserialized.b, vec![2.0, 3.1, -1.2]);
 }
 
 #[test]

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -112,3 +112,30 @@ fn test_deserialize_list_i8() {
     let deserialized: Vec<i8> = yam_serde::from_str(input).unwrap();
     assert_eq!(deserialized, vec![3, 4, 4]);
 }
+
+#[test]
+fn test_enum() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    enum E {
+        Unit,
+        Newtype(u32),
+        Tuple(u32, u32),
+        Struct { a: u32 },
+    }
+
+    let j = r#""Unit""#;
+    let expected = E::Unit;
+    assert_eq!(expected, yam_serde::from_str(j).unwrap());
+    //
+    // let j = r#"{"Newtype":1}"#;
+    // let expected = E::Newtype(1);
+    // assert_eq!(expected, yam_serde::from_str(j).unwrap());
+    //
+    // let j = r#"{"Tuple":[1,2]}"#;
+    // let expected = E::Tuple(1, 2);
+    // assert_eq!(expected, yam_serde::from_str(j).unwrap());
+    //
+    // let j = r#"{"Struct":{"a":1}}"#;
+    // let expected = E::Struct { a: 1 };
+    // assert_eq!(expected, yam_serde::from_str(j).unwrap());
+}

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -8,6 +8,14 @@ pub struct Ex {
 }
 
 #[test]
+fn test_example() {
+    let ex = r#"{ a: "x",  b: "y" }"#;
+    let deserialized: Ex = yam_serde::from_str(ex).unwrap();
+    assert_eq!(deserialized.a, "x");
+    assert_eq!(deserialized.b, "y");
+}
+
+#[test]
 fn test_deserialize_i8() {
     let input = r#"3"#;
     let deserialized: i8 = yam_serde::from_str(input).unwrap();

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -8,15 +8,99 @@ pub struct Ex {
 }
 
 #[test]
-fn test_deserialize_scalar() {
+fn test_deserialize_i8() {
     let input = r#"3"#;
-    let deserialized: i32 = yam_serde::from_str(input).unwrap();
-    assert_eq!(deserialized, 3);
+    let deserialized: i8 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3i8);
 }
 
 #[test]
-fn test_deserialize_list() {
+fn test_deserialize_u8() {
+    let input = r#"3"#;
+    let deserialized: u8 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3u8);
+}
+
+#[test]
+fn test_deserialize_i16() {
+    let input = r#"3"#;
+    let deserialized: i16 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3i16);
+}
+
+#[test]
+fn test_deserialize_u16() {
+    let input = r#"3"#;
+    let deserialized: u16 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3u16);
+}
+
+#[test]
+fn test_deserialize_i32() {
+    let input = r#"3"#;
+    let deserialized: i32 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3i32);
+}
+
+#[test]
+fn test_deserialize_u32() {
+    let input = r#"3"#;
+    let deserialized: u32 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3u32);
+}
+
+#[test]
+fn test_deserialize_i64() {
+    let input = r#"3"#;
+    let deserialized: i64 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3i64);
+}
+
+#[test]
+fn test_deserialize_u64() {
+    let input = r#"3"#;
+    let deserialized: u64 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3u64);
+}
+
+#[test]
+fn test_deserialize_list_i64() {
     let input = r#"[3]"#;
-    let deserialized: Vec<i32> = yam_serde::from_str(input).unwrap();
+    let deserialized: Vec<i64> = yam_serde::from_str(input).unwrap();
     assert_eq!(deserialized, vec![3]);
+}
+
+#[test]
+fn test_deserialize_list_i32() {
+    let input = r#"[3, 4]"#;
+    let deserialized: Vec<i32> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, vec![3, 4]);
+}
+
+#[test]
+fn test_deserialize_list_u16() {
+    let input = r#"[3, 4, 4]"#;
+    let deserialized: Vec<u16> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, vec![3, 4, 4]);
+}
+
+#[test]
+fn test_deserialize_list_i16() {
+    let input = r#"[3, 4, 4]"#;
+    let deserialized: Vec<i16> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, vec![3, 4, 4]);
+}
+
+#[test]
+fn test_deserialize_list_u8() {
+    let input = r#"[3, 4, 4]"#;
+    let deserialized: Vec<u8> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, vec![3, 4, 4]);
+}
+
+#[test]
+fn test_deserialize_list_i8() {
+    let input = r#"[3, 4, 4]"#;
+    let deserialized: Vec<i8> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, vec![3, 4, 4]);
 }

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -114,28 +114,42 @@ fn test_deserialize_list_i8() {
 }
 
 #[test]
+fn test_deserialize_list_f32() {
+    let input = r#"[3, 4, 4]"#;
+    let deserialized: Vec<f32> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, vec![3.0, 4.0, 4.0]);
+}
+
+#[test]
+fn test_deserialize_list_f64() {
+    let input = r#"[3, 4, 4]"#;
+    let deserialized: Vec<f64> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, vec![3.0, 4.0, 4.0]);
+}
+
+#[test]
 fn test_enum() {
     #[derive(Deserialize, PartialEq, Debug)]
     enum E {
         Unit,
-        Newtype(u32),
+        Newtype(f32),
         Tuple(u32, u32),
         Struct { a: u32 },
     }
 
-    // let j = r#""Unit""#;
-    // let expected = E::Unit;
-    // assert_eq!(expected, yam_serde::from_str(j).unwrap());
-    //
-    // let j = r#"{"Newtype": 1}"#;
-    // let expected = E::Newtype(1);
-    // assert_eq!(expected, yam_serde::from_str(j).unwrap());
+    let j = r#""Unit""#;
+    let expected = E::Unit;
+    assert_eq!(expected, yam_serde::from_str(j).unwrap());
+
+    let j = r#"{"Newtype": 1}"#;
+    let expected = E::Newtype(1.0);
+    assert_eq!(expected, yam_serde::from_str(j).unwrap());
 
     let j = r#"{"Tuple":[1,2]}"#;
     let expected = E::Tuple(1, 2);
     assert_eq!(expected, yam_serde::from_str(j).unwrap());
 
-    // let j = r#"{"Struct":{"a":1}}"#;
-    // let expected = E::Struct { a: 1 };
-    // assert_eq!(expected, yam_serde::from_str(j).unwrap());
+    let j = r#"{"Struct":{"a":1}}"#;
+    let expected = E::Struct { a: 1 };
+    assert_eq!(expected, yam_serde::from_str(j).unwrap());
 }

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -13,3 +13,10 @@ fn test_deserialize_scalar() {
     let deserialized: i32 = yam_serde::from_str(input).unwrap();
     assert_eq!(deserialized, 3);
 }
+
+#[test]
+fn test_deserialize_list() {
+    let input = r#"[3]"#;
+    let deserialized: Vec<i32> = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, vec![3]);
+}

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -10,7 +10,6 @@ pub struct Ex {
 #[test]
 fn test_deserialize_scalar() {
     let input = r#"3"#;
-    let deserialized: Ex = yam_serde::from_str(input).unwrap();
-    assert_eq!(deserialized.a, "hello");
-    assert_eq!(deserialized.b, "world");
+    let deserialized: i32 = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized, 3);
 }

--- a/yam-serde/tests/test_serde.rs
+++ b/yam-serde/tests/test_serde.rs
@@ -1,19 +1,16 @@
-// pub use serde;
-// use serde::Deserialize;
-//
-// #[derive(Deserialize, Debug)]
-// pub struct Ex {
-//     a: String,
-//     b: String,
-// }
-//
-// #[test]
-// fn test_deserialize() {
-//     let input = r#"
-//     a: "hello"
-//     b: "world"
-//     "#;
-//     let deserialized: Ex = yam_serde::from_str(input).unwrap();
-//     assert_eq!(deserialized.a, "hello");
-//     assert_eq!(deserialized.b, "world");
-// }
+pub use serde;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct Ex {
+    a: String,
+    b: String,
+}
+
+#[test]
+fn test_deserialize_scalar() {
+    let input = r#"3"#;
+    let deserialized: Ex = yam_serde::from_str(input).unwrap();
+    assert_eq!(deserialized.a, "hello");
+    assert_eq!(deserialized.b, "world");
+}


### PR DESCRIPTION
# Motivation
Adds a crate `yam-serde` that implements [serde](https://docs.rs/serde/latest/serde/) integration for `yam-rs`.

# Implementaiton
- Adds a new iterator that will be used for serde integration.
- Implement a deserializer for `yam-rs` with support for most structures.

# TODO
- Serializer
- Schema-aware node resolver
- `i128` and `f128` implementation.